### PR TITLE
Add a Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ go.work.sum
 # Editor/IDE
 .idea/
 .vscode/
+
+# Nix
+result

--- a/README.md
+++ b/README.md
@@ -341,6 +341,13 @@ sudo rm -f /usr/local/bin/witr
 sudo rm -f /usr/local/share/man/man1/witr.1
 ```
 
+### 8.5 Nix flake
+
+If you use Nix, you can build **witr** from source and run without installation:
+```bash
+nix run github:pranshuparmar/witr -- --port 5000
+```
+
 ---
 
 ## 9. Platform Support

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1766736597,
+        "narHash": "sha256-BASnpCLodmgiVn0M1MU2Pqyoz0aHwar/0qLkp7CjvSQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f560ccec6b1116b22e6ed15f4c510997d99d5852",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+  };
+  outputs =
+    { self, nixpkgs }:
+    {
+      packages = nixpkgs.lib.genAttrs [ "x86_64-linux" "aarch64-linux" ] (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          version = "0.1.0";
+          commit = if self ? rev then self.rev else "dirty";
+          buildDate = pkgs.lib.concatStringsSep "-" [
+            (builtins.substring 0 4 self.lastModifiedDate)
+            (builtins.substring 4 2 self.lastModifiedDate)
+            (builtins.substring 6 2 self.lastModifiedDate)
+          ];
+        in
+        {
+          default = pkgs.buildGoModule {
+            pname = "witr";
+            inherit version;
+            src = pkgs.lib.cleanSource ./.;
+            vendorHash = null;
+            ldflags = [
+              "-X main.version=v${version}"
+              "-X main.commit=${commit}"
+              "-X main.buildDate=${buildDate}"
+            ];
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
Saw this [on Hacker News](https://news.ycombinator.com/item?id=46392910) today; cool project!

This PR adds a small [Nix flake](https://wiki.nixos.org/wiki/Flakes) so that people who don't want to download a prebuilt binary or install **witr** globally can just use [`nix run`](https://nix.dev/manual/nix/2.28/command-ref/new-cli/nix3-run). For instance, if you want to test it out on my fork without merging this PR:

```sh
nix run github:samestep/witr/nix-flake -- --port 5000
```

I'm guessing you won't want to merge this since you're not already a Nix user; that's totally fine. I'm mostly just opening this PR as a convenient place to put this flake in case I want to easily refer back to it in the future. Feel free to close the PR if you'd like.