### PR TITLE
Implementation of socket state detection in Linux

### DIFF
--- a/internal/proc/socketstate_linux.go
+++ b/internal/proc/socketstate_linux.go
@@ -1,4 +1,5 @@
 //go:build linux
+//hugs from brazil
 
 package proc
 


### PR DESCRIPTION
Added the GetSocketStateForPort function. It maps kernel hex TCP states to readable strings and prioritizes tricky states like TIME_WAIT to make debugging easier—just like the macOS version