### PR TITLE
Recognize Colima as a container runtime on macOS

### DIFF
--- a/internal/proc/process_darwin.go
+++ b/internal/proc/process_darwin.go
@@ -215,6 +215,9 @@ func detectContainer(pid int) string {
 	if strings.Contains(lowerCmd, "containerd") {
 		return "containerd"
 	}
+	if strings.Contains(lowerCmd, "colima") {
+		return "colima"
+	}
 
 	return ""
 }


### PR DESCRIPTION
Add Colima detection to container runtime detection