### PR TITLE
Add linker flags to reduce binary size for production releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,19 +26,19 @@ jobs:
 
       - name: Build linux/amd64
         run: |
-          GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version=$VERSION -X main.commit=$COMMIT -X 'main.buildDate=$DATE'" -o witr-linux-amd64 ./cmd/witr
+          GOOS=linux GOARCH=amd64 go build -ldflags "-s -w -X main.version=$VERSION -X main.commit=$COMMIT -X 'main.buildDate=$DATE'" -o witr-linux-amd64 ./cmd/witr
 
       - name: Build linux/arm64
         run: |
-          GOOS=linux GOARCH=arm64 go build -ldflags "-X main.version=$VERSION -X main.commit=$COMMIT -X 'main.buildDate=$DATE'" -o witr-linux-arm64 ./cmd/witr
+          GOOS=linux GOARCH=arm64 go build -ldflags "-s -w -X main.version=$VERSION -X main.commit=$COMMIT -X 'main.buildDate=$DATE'" -o witr-linux-arm64 ./cmd/witr
 
       - name: Build darwin/amd64
         run: |
-          GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.version=$VERSION -X main.commit=$COMMIT -X 'main.buildDate=$DATE'" -o witr-darwin-amd64 ./cmd/witr
+          GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w -X main.version=$VERSION -X main.commit=$COMMIT -X 'main.buildDate=$DATE'" -o witr-darwin-amd64 ./cmd/witr
 
       - name: Build darwin/arm64
         run: |
-          GOOS=darwin GOARCH=arm64 go build -ldflags "-X main.version=$VERSION -X main.commit=$COMMIT -X 'main.buildDate=$DATE'" -o witr-darwin-arm64 ./cmd/witr
+          GOOS=darwin GOARCH=arm64 go build -ldflags "-s -w -X main.version=$VERSION -X main.commit=$COMMIT -X 'main.buildDate=$DATE'" -o witr-darwin-arm64 ./cmd/witr
 
       - name: Generate SHA256SUMS
         run: |


### PR DESCRIPTION
Add linker flags to reduce binary size for production releases

Added -s -w flags to go build ldflags in the release workflow:

- -s: Omit the symbol table and debug information
- -w: Omit the DWARF debugging information

These flags are commonly used for production binaries as they can significantly reduce the final binary size (often by 20-30%).

Trade-offs:
- Debugging becomes more difficult (no symbol names in stack traces)
- Cannot use delve or other debuggers effectively on stripped binaries
- Profiling tools may provide less detailed information

This is an acceptable trade-off for release binaries where size and distribution efficiency matter more than debuggability. Development builds can still be done locally without these flags when debugging is needed.