### PR TITLE
Fix: on macOS, the wrong process start time is reported.

### DIFF
--- a/internal/proc/process_darwin.go
+++ b/internal/proc/process_darwin.go
@@ -15,8 +15,10 @@ import (
 
 func ReadProcess(pid int) (model.Process, error) {
 	// Read process info using ps command on macOS
-	// ps -p <pid> -o pid=,ppid=,uid=,lstart=,state=,ucomm=
-	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "pid=,ppid=,uid=,lstart=,state=,ucomm=").Output()
+	// TZ=UTC ps -p <pid> -o pid=,ppid=,uid=,lstart=,state=,ucomm=
+	cmd := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "pid=,ppid=,uid=,lstart=,state=,ucomm=")
+	cmd.Env = append(os.Environ(), "TZ=UTC")
+	out, err := cmd.Output()
 	if err != nil {
 		return model.Process{}, fmt.Errorf("process %d not found: %w", pid, err)
 	}
@@ -40,7 +42,7 @@ func ReadProcess(pid int) (model.Process, error) {
 	lstartStr := strings.Join(fields[3:8], " ")
 	startedAt, _ := time.Parse("Mon Jan 2 15:04:05 2006", lstartStr)
 	if startedAt.IsZero() {
-		startedAt = time.Now()
+		startedAt = time.Now().UTC()
 	}
 
 	state := fields[8]


### PR DESCRIPTION
Before: the process start time was being printed by `ps` in user's local timezone but without a timezone specifier. The result is parsed by `time.Parse` which assumed UTC, causing the start time to be off by some number of hours.

After: ps is run with TZ=UTC environment variable, so the returned time can be accurately parsed by `time.Parse`.

<img width="1114" height="544" alt="image" src="https://github.com/user-attachments/assets/3e222ce1-99b0-4108-b29f-2e756b03c41b" />
