### PR TITLE
feat: restructure and simplify release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+# .github/workflows/release.yml
 name: Release
 
 on:
@@ -5,57 +6,90 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GO_VERSION: '1.25'
+  PROJECT_NAME: witr
+
 jobs:
-  build-and-release:
+  build:
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ github.ref_name }}
+      COMMIT: ${{ github.sha }}
+    strategy:
+      matrix:
+        os: [ linux, darwin ]
+        arch: [ amd64, arm64 ]
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: ${{ env.GO_VERSION }}
 
-      - name: Set version and commit
-        id: vars
+      - name: Build binary
         run: |
-          echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-          echo "COMMIT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-          echo "DATE=$(date +%Y-%m-%d)" >> $GITHUB_ENV
+          DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          BIN="${PROJECT_NAME}-${{ matrix.os }}-${{ matrix.arch }}"
+          mkdir -p dist
+          CGO_ENABLED=0 \
+          GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} \
+          go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X 'main.buildDate=${DATE}'" -o dist/${BIN} ./cmd/witr
 
-      - name: Build linux/amd64
+      - name: Strip linux binary for smaller size
+        if: matrix.os == 'linux'
         run: |
-          GOOS=linux GOARCH=amd64 go build -ldflags "-s -w -X main.version=$VERSION -X main.commit=$COMMIT -X 'main.buildDate=$DATE'" -o witr-linux-amd64 ./cmd/witr
+          BIN="${PROJECT_NAME}-${{ matrix.os }}-${{ matrix.arch }}"
+          strip dist/${BIN} || true
 
-      - name: Build linux/arm64
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ env.PROJECT_NAME }}-${{ matrix.os }}-${{ matrix.arch }}
+          path: dist/${{ env.PROJECT_NAME }}-${{ matrix.os }}-${{ matrix.arch }}
+
+  publish:
+    name: Publish Release
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout docs only
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            docs/*
+          sparse-checkout-cone-mode: false
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: artifacts
+          pattern: ${{ env.PROJECT_NAME }}-*
+          merge-multiple: true
+
+      - name: Create checksums
         run: |
-          GOOS=linux GOARCH=arm64 go build -ldflags "-s -w -X main.version=$VERSION -X main.commit=$COMMIT -X 'main.buildDate=$DATE'" -o witr-linux-arm64 ./cmd/witr
-
-      - name: Build darwin/amd64
-        run: |
-          GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w -X main.version=$VERSION -X main.commit=$COMMIT -X 'main.buildDate=$DATE'" -o witr-darwin-amd64 ./cmd/witr
-
-      - name: Build darwin/arm64
-        run: |
-          GOOS=darwin GOARCH=arm64 go build -ldflags "-s -w -X main.version=$VERSION -X main.commit=$COMMIT -X 'main.buildDate=$DATE'" -o witr-darwin-arm64 ./cmd/witr
-
-      - name: Generate SHA256SUMS
-        run: |
-          sha256sum witr-linux-amd64 witr-linux-arm64 witr-darwin-amd64 witr-darwin-arm64 > SHA256SUMS
-
-      - name: Copy man page to workspace root
-        run: cp docs/witr.1 ./witr.1
+          sha256sum artifacts/* > SHA256SUMS
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          generate_release_notes: true
           files: |
-            witr-linux-amd64
-            witr-linux-arm64
-            witr-darwin-amd64
-            witr-darwin-arm64
-            SHA256SUMS
-            witr.1
+            artifacts/*
+            docs/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request refactors the GitHub Actions release workflow to improve maintainability, add support for matrix builds, and streamline artifact handling. The workflow now builds binaries for multiple OS/architecture combinations in parallel, strips Linux binaries for smaller size, and uploads artifacts for the release process in a more modular and efficient way.
Similar to #27 but for release.yml
**Workflow structure and build improvements:**

* Refactored the workflow into separate `build` and `publish` jobs, enabling parallel matrix builds for `linux` and `darwin` on both `amd64` and `arm64` architectures, and added concurrency control to prevent overlapping releases.
* Updated Go and checkout actions to the latest major versions (`actions/checkout@v6`, `actions/setup-go@v6`), and centralized environment variable management for versioning and project metadata.

**Artifact and release handling:**

* Changed the binary build process to output files into a `dist` directory with standardized naming, added a step to strip Linux binaries, and now uploads each build as a separate artifact.
* In the `publish` job, downloads all artifacts, generates SHA256 checksums for all binaries, and includes both binaries and documentation in the GitHub Release using the `softprops/action-gh-release` action with automatic release notes. (similar to before)

PS: PR-Summary is ai generated 
