### PR TITLE
Refactor to use slices.Contains

### DIFF
--- a/internal/proc/filecontext_darwin.go
+++ b/internal/proc/filecontext_darwin.go
@@ -4,6 +4,7 @@ package proc
 
 import (
 	"os/exec"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -119,7 +120,7 @@ func getLockedFiles(pid int) []string {
 			if strings.HasSuffix(fileName, ".lock") ||
 				strings.HasSuffix(fileName, ".pid") ||
 				strings.Contains(fileName, "/lock") {
-				if !containsString(locked, fileName) {
+				if !slices.Contains(locked, fileName) {
 					locked = append(locked, fileName)
 				}
 			}
@@ -141,7 +142,7 @@ func getLockedFiles(pid int) []string {
 					// This file has a lock
 					if len(fields) >= 9 {
 						fileName := fields[8]
-						if !containsString(locked, fileName) {
+						if !slices.Contains(locked, fileName) {
 							locked = append(locked, fileName)
 						}
 					}
@@ -151,14 +152,4 @@ func getLockedFiles(pid int) []string {
 	}
 
 	return locked
-}
-
-// containsString checks if a slice contains a string
-func containsString(slice []string, s string) bool {
-	for _, item := range slice {
-		if item == s {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
This PR replaces `containsString` with `slices.Contains`.