### PR TITLE
Refactor to use strings.Lines

### DIFF
--- a/internal/launchd/plist.go
+++ b/internal/launchd/plist.go
@@ -111,8 +111,7 @@ func findServiceByPID(pid int) (string, string) {
 	}
 
 	pidStr := strconv.Itoa(pid)
-	lines := strings.Split(string(out), "\n")
-	for _, line := range lines {
+	for line := range strings.Lines(string(out)) {
 		fields := strings.Fields(line)
 		if len(fields) >= 3 && fields[0] == pidStr {
 			label := fields[2]

--- a/internal/proc/fd_darwin.go
+++ b/internal/proc/fd_darwin.go
@@ -25,8 +25,7 @@ func socketsForPID(pid int) []string {
 	}
 
 	// Parse lsof output
-	lines := strings.Split(string(out), "\n")
-	for _, line := range lines {
+	for line := range strings.Lines(string(out)) {
 		if len(line) == 0 {
 			continue
 		}

--- a/internal/proc/filecontext_darwin.go
+++ b/internal/proc/filecontext_darwin.go
@@ -49,9 +49,8 @@ func getOpenFileCount(pid int) (int, int) {
 	}
 
 	// Count lines (subtract 1 for header)
-	lines := strings.Split(string(out), "\n")
 	openFiles := 0
-	for _, line := range lines {
+	for line := range strings.Lines(string(out)) {
 		if strings.TrimSpace(line) != "" {
 			openFiles++
 		}
@@ -105,8 +104,7 @@ func getLockedFiles(pid int) []string {
 	// f = file descriptor info
 	// n = file name
 	var currentFD string
-	lines := strings.Split(string(out), "\n")
-	for _, line := range lines {
+	for line := range strings.Lines(string(out)) {
 		if len(line) == 0 {
 			continue
 		}
@@ -131,8 +129,7 @@ func getLockedFiles(pid int) []string {
 	// Also check for actual fcntl/flock locks using lsof -F with lock info
 	out2, err := exec.Command("lsof", "-p", strconv.Itoa(pid)).Output()
 	if err == nil {
-		lines := strings.Split(string(out2), "\n")
-		for _, line := range lines {
+		for line := range strings.Lines(string(out2)) {
 			fields := strings.Fields(line)
 			// Look for lock type indicators (varies by lsof version)
 			// Typically shows "r" for read lock, "w" for write lock, "R" for read lock on entire file

--- a/internal/proc/net_darwin.go
+++ b/internal/proc/net_darwin.go
@@ -29,8 +29,7 @@ func readListeningSockets() (map[string]Socket, error) {
 	// p<pid>
 	// n<address>
 	var currentPID string
-	lines := strings.Split(string(out), "\n")
-	for _, line := range lines {
+	for line := range strings.Lines(string(out)) {
 		if len(line) == 0 {
 			continue
 		}
@@ -65,8 +64,7 @@ func readListeningSocketsNetstat() (map[string]Socket, error) {
 		return sockets, nil
 	}
 
-	lines := strings.Split(string(out), "\n")
-	for _, line := range lines {
+	for line := range strings.Lines(string(out)) {
 		if !strings.Contains(line, "LISTEN") {
 			continue
 		}

--- a/internal/proc/process_darwin.go
+++ b/internal/proc/process_darwin.go
@@ -193,8 +193,7 @@ func getWorkingDirectory(pid int) string {
 		return "unknown"
 	}
 
-	lines := strings.Split(string(out), "\n")
-	for _, line := range lines {
+	for line := range strings.Lines(string(out)) {
 		if len(line) > 1 && line[0] == 'n' {
 			return line[1:]
 		}

--- a/internal/proc/process_linux.go
+++ b/internal/proc/process_linux.go
@@ -53,8 +53,7 @@ func ReadProcess(pid int) (model.Process, error) {
 	svcOut, err := exec.Command("systemctl", "status", fmt.Sprintf("%d", pid)).CombinedOutput()
 	if err == nil && strings.Contains(string(svcOut), "Loaded: loaded") {
 		// Try to extract service name from output
-		lines := strings.Split(string(svcOut), "\n")
-		for _, line := range lines {
+		for line := range strings.Lines(string(svcOut)) {
 			if strings.HasPrefix(line, "Loaded:") && strings.Contains(line, ".service") {
 				parts := strings.Fields(line)
 				for _, part := range parts {

--- a/internal/proc/resource_darwin.go
+++ b/internal/proc/resource_darwin.go
@@ -37,11 +37,10 @@ func checkPreventsSleep(pid int) bool {
 	}
 
 	pidStr := strconv.Itoa(pid)
-	lines := strings.Split(string(out), "\n")
 
 	// Look for lines containing our PID in assertion listings
 	// Format varies but typically includes "pid <pid>" or "(<pid>)"
-	for _, line := range lines {
+	for line := range strings.Lines(string(out)) {
 		// Check if this line references our PID and is a sleep prevention assertion
 		if strings.Contains(line, pidStr) {
 			lower := strings.ToLower(line)
@@ -71,8 +70,7 @@ func getThermalState() string {
 	// Look for "CPU_Speed_Limit" or thermal pressure indicators
 	if strings.Contains(output, "CPU_Speed_Limit") {
 		// Extract the speed limit percentage
-		lines := strings.Split(output, "\n")
-		for _, line := range lines {
+		for line := range strings.Lines(output) {
 			if strings.Contains(line, "CPU_Speed_Limit") {
 				// Format: CPU_Speed_Limit = 100
 				parts := strings.Split(line, "=")
@@ -95,8 +93,7 @@ func getThermalState() string {
 
 	// Check for thermal pressure level
 	if strings.Contains(output, "Thermal_Level") {
-		lines := strings.Split(output, "\n")
-		for _, line := range lines {
+		for line := range strings.Lines(output) {
 			if strings.Contains(line, "Thermal_Level") {
 				parts := strings.Split(line, "=")
 				if len(parts) >= 2 {

--- a/internal/proc/socketstate_darwin.go
+++ b/internal/proc/socketstate_darwin.go
@@ -25,8 +25,7 @@ func GetSocketStates(port int) ([]model.SocketInfo, error) {
 	portSuffix := fmt.Sprintf(".%d", port)
 	portColonSuffix := fmt.Sprintf(":%d", port)
 
-	lines := strings.Split(string(out), "\n")
-	for _, line := range lines {
+	for line := range strings.Lines(string(out)) {
 		fields := strings.Fields(line)
 		if len(fields) < 6 {
 			continue

--- a/internal/proc/user_linux.go
+++ b/internal/proc/user_linux.go
@@ -30,8 +30,7 @@ func readUser(pid int) string {
 	uidStr := strconv.Itoa(uid)
 	passwd, err := os.ReadFile("/etc/passwd")
 	if err == nil {
-		lines := strings.Split(string(passwd), "\n")
-		for _, line := range lines {
+		for line := range strings.Lines(string(passwd)) {
 			fields := strings.Split(line, ":")
 			if len(fields) > 2 && fields[2] == uidStr {
 				return fields[0]

--- a/internal/target/name_darwin.go
+++ b/internal/target/name_darwin.go
@@ -37,8 +37,7 @@ func ResolveName(name string) ([]int, error) {
 		return nil, fmt.Errorf("failed to list processes: %w", err)
 	}
 
-	lines := strings.Split(string(out), "\n")
-	for _, line := range lines {
+	for line := range strings.Lines(string(out)) {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
@@ -165,8 +164,7 @@ func resolveLaunchdServicePID(name string) (int, error) {
 		if err == nil {
 			// Parse output to find PID
 			// Look for "pid = <number>"
-			lines := strings.Split(string(out), "\n")
-			for _, line := range lines {
+			for line := range strings.Lines(string(out)) {
 				line = strings.TrimSpace(line)
 				if strings.HasPrefix(line, "pid = ") {
 					pidStr := strings.TrimPrefix(line, "pid = ")

--- a/internal/target/port_darwin.go
+++ b/internal/target/port_darwin.go
@@ -63,9 +63,8 @@ func resolvePortNetstat(port int) ([]int, error) {
 	}
 
 	portStr := fmt.Sprintf(".%d", port)
-	lines := strings.Split(string(out), "\n")
 
-	for _, line := range lines {
+	for line := range strings.Lines(string(out)) {
 		if !strings.Contains(line, "LISTEN") {
 			continue
 		}


### PR DESCRIPTION
This PR replaces `strings.Split` with a slightly more efficient [`strings.Lines`](https://pkg.go.dev/strings#Lines).