### PR TITLE
fix: Add missing SHA256SUMS to release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,5 +91,6 @@ jobs:
           files: |
             artifacts/*
             docs/*
+            SHA256SUMS
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When I did #45 I forgot to add the checksums to the release artefacts.

Closes #61 