### PR TITLE
fix: parse Linux process state correctly

### DIFF
--- a/internal/proc/process_linux.go
+++ b/internal/proc/process_linux.go
@@ -116,7 +116,7 @@ func ReadProcess(pid int) (model.Process, error) {
 	fields := strings.Fields(raw[close+2:])
 
 	ppid, _ := strconv.Atoi(fields[1])
-	state := fields[2]
+	state := processState(fields)
 	startTicks, _ := strconv.ParseInt(fields[19], 10, 64)
 
 	// Fork detection: if ppid != 1 and not systemd, likely forked; also check for vfork/fork/clone flags if possible
@@ -192,4 +192,16 @@ func ReadProcess(pid int) (model.Process, error) {
 		Forked:         forked,
 		Env:            env,
 	}, nil
+}
+
+// The kernel emits the state immediately after the command, so fields[0] always carries it.
+func processState(fields []string) string {
+	if len(fields) == 0 {
+		return ""
+	}
+	state := fields[0]
+	if len(state) == 0 {
+		return ""
+	}
+	return state[:1]
 }


### PR DESCRIPTION
The Linux parser misread /proc/<pid>/stat. After stripping the (comm) segment, the kernel emits fields as STATE PPID PGRP ...

But the original code grabbed fields[2] and treated it as the state. fields[2] is actually the process-group ID (e.g., 4420 in 4221 (sleep) Z 4420 …), so state never became Z or T, the “zombie/stopped” branches never fired, and the health flag stayed “healthy”. 

The fix simply reads the first field (fields[0]) and guards the slice so malformed input can’t panic.

Closes #65 