### PR TITLE
nix: tiny cleanup

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,14 +3,20 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
   };
   outputs =
-    { self, nixpkgs }:
     {
-      packages = nixpkgs.lib.genAttrs [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ] (
+      self,
+      nixpkgs,
+    }:
+    let
+      inherit (nixpkgs) lib;
+    in
+    {
+      packages = lib.genAttrs [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ] (
         system:
         let
-          pkgs = import nixpkgs { inherit system; };
+          pkgs = nixpkgs.legacyPackages.${system};
           version = if self ? rev then "git-${builtins.substring 0 7 self.rev}" else "dirty";
-          commit = if self ? rev then self.rev else "dirty";
+          commit = self.rev or "dirty";
           buildDate = pkgs.lib.concatStringsSep "-" [
             (builtins.substring 0 4 self.lastModifiedDate)
             (builtins.substring 4 2 self.lastModifiedDate)
@@ -21,13 +27,39 @@
           default = pkgs.buildGoModule {
             pname = "witr";
             inherit version;
-            src = pkgs.lib.cleanSource ./.;
+            src = lib.cleanSourceWith {
+              src = ./.;
+              filter =
+                path: _:
+                let
+                  pathRelative = lib.removePrefix (toString ./.) (toString path);
+                in
+                builtins.any (p: lib.hasPrefix p pathRelative) [
+                  "/go.mod"
+                  "/internal"
+                  "/pkg"
+                  "/cmd"
+                  "/doc"
+                ];
+            };
+
             vendorHash = null;
             ldflags = [
               "-X main.version=v${version}"
               "-X main.commit=${commit}"
               "-X main.buildDate=${buildDate}"
             ];
+
+            nativeBuildInputs = [ pkgs.installShellFiles ];
+            postInstall = ''
+              installManPage ./doc/witr.*
+            '';
+
+            meta = {
+              description = "Why is this running?";
+              homepage = "https://github.com/pranshuparmar/witr";
+              license = lib.licenses.asl20;
+            };
           };
         }
       );


### PR DESCRIPTION
Hello!

While working on a small patch for witr I've noticed that the Nix flake is a bit inefficient, so I've cleaned it up a little. This might seem rather opitionated and drastic, but it's made with good intentions I assure you. A short summary of my changes:

1. I've changed `import nixpkgs { inherit system; };` to `nixpkgs.legacyPackages.${system}` because the latter is a tiny bit more efficient. [This post](https://zimbatm.com/notes/1000-instances-of-nixpkgs) generally covers what the issue is, and the alternative pattern I've used. Long thing short, we aren't using overlays, so the `import` pattern is unnecessary. And less efficient.

2. Changes `pkgs.lib` invocations to `nixpkgs.lib`, since former is always in scope due to the argset. We don't have to partially instantiate `pkgs` for lib. Though the position of the `let in` might be bothersome. Let me know if you want this changed.

3. Changed the source filter to a more aggressive one to prevent unnecessary rebuilds. In the previous version, you would rebuild the package even when an irrelevant package has changed (say, your README.md) because the source filter actually covers so little. See [here](https://github.com/NixOS/nixpkgs/blob/a338f62ea8defe7b0946f9718204c29105524b35/lib/sources.nix#L94:C5) for the things covered. Instead, we make a "static" filter that specifies the files needed for the build, and the source is changed only when one of the *relevant* files are changed. This is nice to avoid unnecessary rebuilds.

4. Add a `postInstall` step to install the manpages. This is not done automatically, so we have to use the `installShellFiles` hook. This is trivial and cost-free, so might as well.

5. Added the `meta` field with description and license fields. Those are critical for various commands, i.e., the former is displayed in `nix flake show` nicely and the latter avoids getting `unfree` warnings. Also went ahead and added the homepage because, well, documentation is nice.

Lastly, I had to reformat the file with a conventional formatter because I could not figure out what you were using, and my formatter nuked the file *after* I have made all of my changes. If you'd like me to reformat, I can do that *or* I can add `pkgs.nixfmt` as the standard formatter for the flake so it works with `nix fmt` automatically.

Change-Id: Ic8a9ddb1e3e3bc56b81888230706cdf96a6a6964