### PR TITLE
feat: add warnings on `LD_PRELOAD` and `DYDL_*` env vars

### DIFF
--- a/internal/source/detect_test.go
+++ b/internal/source/detect_test.go
@@ -1,0 +1,178 @@
+package source
+
+import (
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pranshuparmar/witr/pkg/model"
+)
+
+func TestWarningsDetectsLDPreload(t *testing.T) {
+	p := []model.Process{
+		{PID: 999999, Command: "pm2", Cmdline: "pm2"},
+		{
+			PID:        123,
+			Command:    "bash",
+			StartedAt:  time.Now(),
+			User:       "bob",
+			WorkingDir: "/home/bob",
+			Env:        []string{"LD_PRELOAD=/tmp/libhack.so"},
+		},
+	}
+
+	warnings := Warnings(p)
+	if !slices.Contains(warnings, "Process sets LD_PRELOAD (potential library injection)") {
+		t.Fatalf("expected LD_PRELOAD warning, got: %v", warnings)
+	}
+}
+
+func TestWarningsDetectsDYLDVars(t *testing.T) {
+	p := []model.Process{
+		{PID: 999999, Command: "pm2", Cmdline: "pm2"},
+		{
+			PID:        123,
+			Command:    "zsh",
+			StartedAt:  time.Now(),
+			User:       "bob",
+			WorkingDir: "/home/bob",
+			Env: []string{
+				"DYLD_LIBRARY_PATH=/tmp",
+				"DYLD_INSERT_LIBRARIES=/tmp/inject.dylib",
+			},
+		},
+	}
+
+	warnings := Warnings(p)
+	want := "Process sets DYLD_* variables (potential library injection): DYLD_INSERT_LIBRARIES, DYLD_LIBRARY_PATH"
+	if !slices.Contains(warnings, want) {
+		t.Fatalf("expected DYLD warning %q, got: %v", want, warnings)
+	}
+}
+
+func TestWarningsIgnoresEmptyPreloadVars(t *testing.T) {
+	p := []model.Process{
+		{PID: 999999, Command: "pm2", Cmdline: "pm2"},
+		{
+			PID:        123,
+			Command:    "zsh",
+			StartedAt:  time.Now(),
+			User:       "bob",
+			WorkingDir: "/home/bob",
+			Env: []string{
+				"LD_PRELOAD=",
+				"DYLD_INSERT_LIBRARIES=",
+			},
+		},
+	}
+
+	warnings := Warnings(p)
+	if slices.Contains(warnings, "Process sets LD_PRELOAD (potential library injection)") {
+		t.Fatalf("did not expect LD_PRELOAD warning, got: %v", warnings)
+	}
+	if slices.Contains(warnings, "Process sets DYLD_* variables (potential library injection): DYLD_INSERT_LIBRARIES") {
+		t.Fatalf("did not expect DYLD warning, got: %v", warnings)
+	}
+}
+
+// checks if the order of env vars warnings are deterministic
+func FuzzEnvSuspiciousWarningsDeterministic(f *testing.F) {
+	f.Add("LD_PRELOAD=/tmp/lib.so")
+	f.Add("DYLD_LIBRARY_PATH=/tmp\nDYLD_INSERT_LIBRARIES=/tmp/inject.dylib")
+	f.Add("DYLD_LIBRARY_PATH=\nLD_PRELOAD=")
+	f.Add("")
+
+	f.Fuzz(func(t *testing.T, input string) {
+		parts := strings.Split(input, "\n")
+		if len(parts) > 50 {
+			parts = parts[:50]
+		}
+		for i := range parts {
+			if len(parts[i]) > 200 {
+				parts[i] = parts[i][:200]
+			}
+		}
+
+		w1 := envSuspiciousWarnings(parts)
+		w2 := envSuspiciousWarnings(parts)
+		if !slices.Equal(w1, w2) {
+			t.Fatalf("expected deterministic output, got %v vs %v", w1, w2)
+		}
+	})
+}
+
+func TestEnvSuspiciousWarnings(t *testing.T) {
+	tests := []struct {
+		name string
+		env  []string
+		want []string
+	}{
+		{
+			name: "LD_PRELOAD",
+			env:  []string{"LD_PRELOAD=/tmp/libhack.so"},
+			want: []string{"Process sets LD_PRELOAD (potential library injection)"},
+		},
+		{
+			name: "DYLD keys sorted and deduped",
+			env: []string{
+				"DYLD_LIBRARY_PATH=/tmp",
+				"DYLD_INSERT_LIBRARIES=/tmp/inject.dylib",
+				"DYLD_LIBRARY_PATH=/tmp", // dup
+			},
+			want: []string{
+				"Process sets DYLD_* variables (potential library injection): DYLD_INSERT_LIBRARIES, DYLD_LIBRARY_PATH",
+			},
+		},
+		{
+			name: "ignores empty values (current behavior)",
+			env:  []string{"LD_PRELOAD=", "DYLD_INSERT_LIBRARIES="},
+			want: nil,
+		},
+		{
+			name: "value with '=' still counts",
+			env:  []string{"LD_PRELOAD=a=b"},
+			want: []string{"Process sets LD_PRELOAD (potential library injection)"},
+		},
+		{
+			name: "no '=' ignored",
+			env:  []string{"LD_PRELOAD"},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := envSuspiciousWarnings(tt.env)
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// attempts to cause a panic when checking for env vars
+func FuzzWarningsNoPanic(f *testing.F) {
+	f.Add("LD_PRELOAD=/tmp/lib.so")
+	f.Add("DYLD_INSERT_LIBRARIES=/tmp/inject.dylib")
+	f.Add("NOT_AN_ENV")
+
+	f.Fuzz(func(t *testing.T, entry string) {
+		if len(entry) > 2000 {
+			entry = entry[:2000]
+		}
+		p := []model.Process{
+			{
+				PID:        123,
+				Command:    "test",
+				Cmdline:    "test",
+				StartedAt:  time.Now(),
+				User:       "bob",
+				WorkingDir: "/home/bob",
+				Env:        []string{entry},
+			},
+		}
+
+		_ = Warnings(p)
+	})
+}


### PR DESCRIPTION
Adds warnings for env-driven library injection patterns with a small unit + fuzz test suite. The rule table is intentionally small and easy to extend.

- Add warnings when a target process sets `LD_PRELOAD` or `DYLD_*`
- Add unit tests and fuzz tests for warning stability

Example output:

<img width="2018" height="797" alt="image" src="https://github.com/user-attachments/assets/405d97c9-a2d0-452c-a8e9-fd310f35b606" />
