### PR TITLE
Add FreeBSD support

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -49,6 +49,10 @@ jobs:
             arch: amd64
           - os: darwin
             arch: arm64
+          - os: freebsd
+            arch: amd64
+          - os: freebsd
+            arch: arm64
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,7 @@ builds:
     goos:
       - linux
       - darwin
+      - freebsd
     goarch:
       - amd64
       - arm64

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build linux || darwin || freebsd
 
 package cmd
 

--- a/cmd/witr/main.go
+++ b/cmd/witr/main.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build linux || darwin || freebsd
 
 package main
 

--- a/cmd/witr/unsupported.go
+++ b/cmd/witr/unsupported.go
@@ -1,4 +1,4 @@
-//go:build !linux && !darwin
+//go:build !linux && !darwin && !freebsd
 
 package main
 
@@ -10,7 +10,7 @@ import (
 func main() {
 	fmt.Fprintln(
 		os.Stderr,
-		"witr is only supported on Linux and macOS.\n\nIf you are seeing this message, you are attempting to build or run witr on an unsupported platform (such as Windows).\n\nPlease use Linux or macOS to build and run witr.",
+		"witr is only supported on Linux, macOS, and FreeBSD.\n\nIf you are seeing this message, you are attempting to build or run witr on an unsupported platform (such as Windows).\n\nPlease use Linux, macOS, or FreeBSD to build and run witr.",
 	)
 	os.Exit(1)
 }

--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,9 @@ case "$OS" in
     darwin)
         OS=darwin
         ;;
+    freebsd)
+        OS=freebsd
+        ;;
     *)
         echo "Unsupported OS: $OS" >&2
         exit 1

--- a/internal/proc/boot_freebsd.go
+++ b/internal/proc/boot_freebsd.go
@@ -1,0 +1,39 @@
+//go:build freebsd
+
+package proc
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func bootTime() time.Time {
+	// Use sysctl kern.boottime on FreeBSD (same format as macOS)
+	out, err := exec.Command("sysctl", "-n", "kern.boottime").Output()
+	if err != nil {
+		return time.Now()
+	}
+
+	// Output format: { sec = 1703123456, usec = 123456 } ...
+	outStr := string(out)
+	if idx := strings.Index(outStr, "sec = "); idx != -1 {
+		start := idx + 6
+		end := strings.Index(outStr[start:], ",")
+		if end != -1 {
+			secStr := outStr[start : start+end]
+			sec, err := strconv.ParseInt(strings.TrimSpace(secStr), 10, 64)
+			if err == nil {
+				return time.Unix(sec, 0)
+			}
+		}
+	}
+
+	return time.Now()
+}
+
+func ticksPerSecond() time.Duration {
+	// FreeBSD default (same as Linux/macOS)
+	return 100
+}

--- a/internal/proc/cmdline_freebsd.go
+++ b/internal/proc/cmdline_freebsd.go
@@ -1,0 +1,30 @@
+//go:build freebsd
+
+package proc
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// GetCmdline returns the command line for a given PID
+func GetCmdline(pid int) string {
+	// FreeBSD syntax: ps -p <pid> -o args
+	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "args").Output()
+	if err != nil {
+		return "(unknown)"
+	}
+
+	// Skip header line
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) < 2 {
+		return "(unknown)"
+	}
+
+	cmdline := strings.TrimSpace(lines[1])
+	if cmdline == "" {
+		return "(unknown)"
+	}
+	return cmdline
+}

--- a/internal/proc/filecontext_freebsd.go
+++ b/internal/proc/filecontext_freebsd.go
@@ -1,0 +1,125 @@
+//go:build freebsd
+
+package proc
+
+import (
+	"os/exec"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/pranshuparmar/witr/pkg/model"
+)
+
+// GetFileContext returns file descriptor and lock info for a process
+func GetFileContext(pid int) *model.FileContext {
+	ctx := &model.FileContext{}
+
+	// Get open file count
+	openFiles, fileLimit := getOpenFileCount(pid)
+	ctx.OpenFiles = openFiles
+	ctx.FileLimit = fileLimit
+
+	// Get locked files
+	ctx.LockedFiles = getLockedFiles(pid)
+
+	// Only return if we have meaningful data to show
+	// Show if: high file usage (>50% of limit) or has locks
+	if len(ctx.LockedFiles) > 0 {
+		return ctx
+	}
+
+	if ctx.FileLimit > 0 && ctx.OpenFiles > 0 {
+		usagePercent := float64(ctx.OpenFiles) / float64(ctx.FileLimit) * 100
+		if usagePercent > 50 {
+			return ctx
+		}
+	}
+
+	return nil
+}
+
+// getOpenFileCount returns the number of open files and the limit for a process
+func getOpenFileCount(pid int) (int, int) {
+	// Use fstat to count open files
+	out, err := exec.Command("fstat", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return 0, 0
+	}
+
+	// Count lines (subtract 1 for header)
+	openFiles := 0
+	for line := range strings.Lines(string(out)) {
+		if strings.TrimSpace(line) != "" {
+			openFiles++
+		}
+	}
+	if openFiles > 0 {
+		openFiles-- // Subtract header line
+	}
+
+	// Get file limit using sysctl or limits
+	fileLimit := getFileLimit(pid)
+
+	return openFiles, fileLimit
+}
+
+// getFileLimit returns the file descriptor limit for a process
+func getFileLimit(pid int) int {
+	// Try procstat to get limits
+	out, err := exec.Command("procstat", "-l", strconv.Itoa(pid)).Output()
+	if err == nil {
+		// Parse procstat -l output for openfiles limit
+		for line := range strings.Lines(string(out)) {
+			if strings.Contains(line, "openfiles") {
+				fields := strings.Fields(line)
+				if len(fields) >= 3 {
+					limit, err := strconv.Atoi(fields[2])
+					if err == nil {
+						return limit
+					}
+				}
+			}
+		}
+	}
+
+	// Fallback: get system-wide limit
+	out, err = exec.Command("sysctl", "-n", "kern.maxfilesperproc").Output()
+	if err == nil {
+		limit, err := strconv.Atoi(strings.TrimSpace(string(out)))
+		if err == nil {
+			return limit
+		}
+	}
+
+	// Default FreeBSD limit
+	return 1024
+}
+
+// getLockedFiles returns files with locks held by the process
+func getLockedFiles(pid int) []string {
+	var locked []string
+
+	// Use fstat to find file locks
+	out, err := exec.Command("fstat", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return locked
+	}
+
+	for line := range strings.Lines(string(out)) {
+		// Look for lock indicators in the output
+		if strings.Contains(line, ".lock") ||
+			strings.Contains(line, ".pid") ||
+			strings.Contains(line, "/lock") {
+			fields := strings.Fields(line)
+			if len(fields) >= 8 {
+				fileName := fields[len(fields)-1]
+				if !slices.Contains(locked, fileName) {
+					locked = append(locked, fileName)
+				}
+			}
+		}
+	}
+
+	return locked
+}

--- a/internal/proc/net_freebsd.go
+++ b/internal/proc/net_freebsd.go
@@ -1,0 +1,163 @@
+//go:build freebsd
+
+package proc
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// readListeningSockets returns a map of pseudo-inodes to sockets
+// On FreeBSD, we use sockstat to get listening sockets
+// We use a combination of PID:port as the "inode" since FreeBSD doesn't expose inodes like Linux
+func readListeningSockets() (map[string]Socket, error) {
+	sockets := make(map[string]Socket)
+
+	// Use sockstat to get listening TCP sockets
+	// -4 = IPv4, -6 = IPv6, -l = listening, -P tcp = TCP protocol
+	// Run for both IPv4 and IPv6
+	for _, flag := range []string{"-4", "-6"} {
+		out, err := exec.Command("sockstat", flag, "-l", "-P", "tcp").Output()
+		if err != nil {
+			continue
+		}
+
+		parseSockstatOutput(string(out), sockets)
+	}
+
+	if len(sockets) == 0 {
+		// Try netstat as fallback
+		return readListeningSocketsNetstat()
+	}
+
+	return sockets, nil
+}
+
+func parseSockstatOutput(output string, sockets map[string]Socket) {
+	// sockstat output format:
+	// USER     COMMAND    PID   FD PROTO  LOCAL ADDRESS         FOREIGN ADDRESS
+	// root     nginx      1234  6  tcp4   *:80                  *:*
+
+	for line := range strings.Lines(output) {
+		fields := strings.Fields(line)
+		if len(fields) < 6 {
+			continue
+		}
+
+		// Skip header
+		if fields[0] == "USER" {
+			continue
+		}
+
+		pid := fields[2]
+		localAddr := fields[5]
+
+		// Parse local address
+		address, port := parseSockstatAddr(localAddr)
+		if port > 0 {
+			// Use PID:port as pseudo-inode
+			inode := pid + ":" + strconv.Itoa(port)
+			sockets[inode] = Socket{
+				Inode:   inode,
+				Port:    port,
+				Address: address,
+			}
+		}
+	}
+}
+
+func readListeningSocketsNetstat() (map[string]Socket, error) {
+	sockets := make(map[string]Socket)
+
+	// Use netstat as fallback
+	// netstat -an -p tcp shows all TCP connections
+	out, err := exec.Command("netstat", "-an", "-p", "tcp").Output()
+	if err != nil {
+		return sockets, nil
+	}
+
+	for line := range strings.Lines(string(out)) {
+		if !strings.Contains(line, "LISTEN") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+		// Local address is typically field 3 (0-indexed)
+		localAddr := fields[3]
+		address, port := parseSockstatAddr(localAddr)
+		if port > 0 {
+			// Generate a unique key
+			inode := "netstat:" + localAddr
+			sockets[inode] = Socket{
+				Inode:   inode,
+				Port:    port,
+				Address: address,
+			}
+		}
+	}
+
+	return sockets, nil
+}
+
+// parseSockstatAddr parses addresses like "*:80", "127.0.0.1:8080", "[::1]:8080"
+func parseSockstatAddr(addr string) (string, int) {
+	// Handle IPv6 format [::]:port or [::1]:port
+	if strings.HasPrefix(addr, "[") {
+		bracketEnd := strings.LastIndex(addr, "]")
+		if bracketEnd == -1 {
+			return "", 0
+		}
+		ip := addr[1:bracketEnd]
+		rest := addr[bracketEnd+1:]
+		// rest should be ":port"
+		if len(rest) > 1 && rest[0] == ':' {
+			port, err := strconv.Atoi(rest[1:])
+			if err == nil {
+				if ip == "::" || ip == "" {
+					return "::", port
+				}
+				return ip, port
+			}
+		}
+		return "", 0
+	}
+
+	// Handle wildcard format "*:port"
+	if strings.HasPrefix(addr, "*:") {
+		port, err := strconv.Atoi(addr[2:])
+		if err == nil {
+			return "0.0.0.0", port
+		}
+		return "", 0
+	}
+
+	// Handle IPv4 format "127.0.0.1:8080"
+	// FreeBSD sockstat uses colon as separator
+	if idx := strings.LastIndex(addr, ":"); idx != -1 {
+		ip := addr[:idx]
+		portStr := addr[idx+1:]
+		port, err := strconv.Atoi(portStr)
+		if err == nil {
+			if ip == "*" {
+				return "0.0.0.0", port
+			}
+			return ip, port
+		}
+	}
+
+	// Handle dot-separated format (some FreeBSD versions)
+	// "127.0.0.1.8080"
+	if idx := strings.LastIndex(addr, "."); idx != -1 {
+		portStr := addr[idx+1:]
+		port, err := strconv.Atoi(portStr)
+		if err == nil {
+			ip := addr[:idx]
+			return ip, port
+		}
+	}
+
+	return "", 0
+}

--- a/internal/proc/process_freebsd.go
+++ b/internal/proc/process_freebsd.go
@@ -1,0 +1,441 @@
+//go:build freebsd
+
+package proc
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pranshuparmar/witr/pkg/model"
+)
+
+func ReadProcess(pid int) (model.Process, error) {
+	// Read process info using ps command on FreeBSD
+	// FreeBSD ps uses different syntax: -o pid -o ppid (separate -o for each field)
+	// Note: FreeBSD ps always outputs headers, we need to skip them
+
+	pidStr := strconv.Itoa(pid)
+
+	// Get basic process info: pid, ppid, uid, state, comm
+	cmd := exec.Command("ps", "-p", pidStr, "-o", "pid", "-o", "ppid", "-o", "uid", "-o", "state", "-o", "comm")
+	cmd.Env = buildEnvForPS()
+	out, err := cmd.Output()
+	if err != nil {
+		return model.Process{}, fmt.Errorf("process %d not found: %w", pid, err)
+	}
+
+	// Skip header line and get data line
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) < 2 {
+		return model.Process{}, fmt.Errorf("process %d not found", pid)
+	}
+
+	// Parse second line (skip header): pid ppid uid state comm
+	fields := strings.Fields(lines[1])
+	if len(fields) < 5 {
+		return model.Process{}, fmt.Errorf("unexpected ps output format for pid %d: got %d fields in %q", pid, len(fields), lines[1])
+	}
+
+	ppid, _ := strconv.Atoi(fields[1])
+	uid, _ := strconv.Atoi(fields[2])
+	state := fields[3]
+	comm := fields[4]
+
+	// Get start time separately
+	startedAt := getProcessStartTime(pid)
+	if startedAt.IsZero() {
+		startedAt = time.Now().UTC()
+	}
+
+	// Get full command line
+	cmdline := getCommandLine(pid)
+	if cmdline == "" {
+		cmdline = comm
+	}
+
+	// Get environment variables
+	env := getEnvironment(pid)
+
+	// Get working directory
+	cwd := getWorkingDirectory(pid)
+
+	// Health status
+	health := "healthy"
+	forked := "unknown"
+
+	// FreeBSD states can be multi-character like "Is", "Ss", "R", "Z", "T"
+	// Check first character for main state
+	if len(state) > 0 {
+		switch state[0] {
+		case 'Z':
+			health = "zombie"
+		case 'T':
+			health = "stopped"
+		}
+	}
+
+	// Fork detection
+	if ppid != 1 && comm != "init" {
+		forked = "forked"
+	} else {
+		forked = "not-forked"
+	}
+
+	// Get user from UID
+	user := readUserByUID(uid)
+
+	// Container detection on FreeBSD (jails)
+	container := detectContainer(pid)
+
+	if comm == "docker-proxy" && container == "" {
+		container = resolveDockerProxyContainer(cmdline)
+	}
+
+	// Service detection (rc.d)
+	service := detectRcService(pid)
+
+	// Git repo/branch detection
+	gitRepo, gitBranch := detectGitInfo(cwd)
+
+	// Get listening ports for this process
+	sockets, _ := readListeningSockets()
+	inodes := socketsForPID(pid)
+
+	var ports []int
+	var addrs []string
+
+	for _, inode := range inodes {
+		if s, ok := sockets[inode]; ok {
+			ports = append(ports, s.Port)
+			addrs = append(addrs, s.Address)
+		}
+	}
+
+	// Check for high resource usage
+	health = checkResourceUsage(pid, health)
+
+	return model.Process{
+		PID:            pid,
+		PPID:           ppid,
+		Command:        comm,
+		Cmdline:        cmdline,
+		StartedAt:      startedAt,
+		User:           user,
+		WorkingDir:     cwd,
+		GitRepo:        gitRepo,
+		GitBranch:      gitBranch,
+		Container:      container,
+		Service:        service,
+		ListeningPorts: ports,
+		BindAddresses:  addrs,
+		Health:         health,
+		Forked:         forked,
+		Env:            env,
+	}, nil
+}
+
+func getProcessStartTime(pid int) time.Time {
+	// Get start time using ps lstart
+	// FreeBSD syntax: ps -p <pid> -o lstart
+	cmd := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "lstart")
+	cmd.Env = buildEnvForPS()
+	out, err := cmd.Output()
+	if err != nil {
+		return time.Time{}
+	}
+
+	// Skip header line
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) < 2 {
+		return time.Time{}
+	}
+
+	lstartStr := strings.TrimSpace(lines[1])
+	if lstartStr == "" {
+		return time.Time{}
+	}
+
+	// FreeBSD lstart format with LC_ALL=C: "Thu Jan  2 10:26:00 2025"
+	// Try multiple formats
+	formats := []string{
+		"Mon Jan 2 15:04:05 2006",
+		"Mon Jan  2 15:04:05 2006",
+		"Mon Jan 02 15:04:05 2006",
+	}
+
+	for _, format := range formats {
+		if t, err := time.Parse(format, lstartStr); err == nil {
+			return t
+		}
+	}
+
+	return time.Time{}
+}
+
+func getCommandLine(pid int) string {
+	// Use ps to get full command line
+	// FreeBSD syntax: ps -p <pid> -o args
+	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "args").Output()
+	if err != nil {
+		return ""
+	}
+
+	// Skip header line
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) < 2 {
+		return ""
+	}
+	return strings.TrimSpace(lines[1])
+}
+
+func getEnvironment(pid int) []string {
+	var env []string
+
+	// On FreeBSD, try procfs first if mounted
+	procEnvPath := fmt.Sprintf("/proc/%d/environ", pid)
+	if envBytes, err := os.ReadFile(procEnvPath); err == nil {
+		for _, e := range strings.Split(string(envBytes), "\x00") {
+			if e != "" {
+				env = append(env, e)
+			}
+		}
+		return env
+	}
+
+	// Fallback: use procstat -e if available
+	out, err := exec.Command("procstat", "-e", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return env
+	}
+
+	// Parse procstat -e output
+	// Format: PID COMM ENVVAR=VALUE ...
+	for line := range strings.Lines(string(out)) {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		// Skip header and PID/COMM columns
+		for _, field := range fields[2:] {
+			if strings.Contains(field, "=") {
+				env = append(env, field)
+			}
+		}
+	}
+
+	return env
+}
+
+func getWorkingDirectory(pid int) string {
+	// Try procfs first if mounted
+	procCwdPath := fmt.Sprintf("/proc/%d/cwd", pid)
+	if cwd, err := os.Readlink(procCwdPath); err == nil {
+		return cwd
+	}
+
+	// Fallback: use procstat -f to get current working directory
+	// procstat -f shows file descriptors, including a special "cwd" entry
+	out, err := exec.Command("procstat", "-f", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return "unknown"
+	}
+
+	// Parse procstat -f output for cwd
+	// Output format: PID COMM FD TYPE FLAGS ... PATH
+	// The cwd line has "cwd" in the FD column (typically 3rd column)
+	for line := range strings.Lines(string(out)) {
+		fields := strings.Fields(line)
+		// Look for the line where FD column is "cwd"
+		// Typical format has at least: PID COMM FD TYPE ... PATH
+		if len(fields) >= 4 && fields[2] == "cwd" {
+			// The path is in the last column
+			return fields[len(fields)-1]
+		}
+	}
+
+	return "unknown"
+}
+
+func detectContainer(pid int) string {
+	// On FreeBSD, check if running inside a jail
+	// Use jls to check jail status
+	out, err := exec.Command("jls", "-j", strconv.Itoa(pid)).Output()
+	if err == nil && strings.TrimSpace(string(out)) != "" {
+		return "jail"
+	}
+
+	// Check command line for container patterns
+	cmdline := getCommandLine(pid)
+	lowerCmd := strings.ToLower(cmdline)
+
+	switch {
+	case strings.Contains(lowerCmd, "docker"):
+		return "docker"
+	case strings.Contains(lowerCmd, "podman"), strings.Contains(lowerCmd, "libpod"):
+		return "podman"
+	case strings.Contains(lowerCmd, "kubepods"):
+		return "kubernetes"
+	case strings.Contains(lowerCmd, "containerd"):
+		return "containerd"
+	}
+
+	return ""
+}
+
+func detectRcService(pid int) string {
+	// FreeBSD uses rc.d for service management
+	// Try to find the service by checking /var/run/*.pid files
+	pidStr := strconv.Itoa(pid)
+
+	entries, err := os.ReadDir("/var/run")
+	if err != nil {
+		return ""
+	}
+
+	for _, entry := range entries {
+		if !strings.HasSuffix(entry.Name(), ".pid") {
+			continue
+		}
+
+		pidFile := "/var/run/" + entry.Name()
+		content, err := os.ReadFile(pidFile)
+		if err != nil {
+			continue
+		}
+
+		if strings.TrimSpace(string(content)) == pidStr {
+			// Found matching PID file
+			serviceName := strings.TrimSuffix(entry.Name(), ".pid")
+			return serviceName
+		}
+	}
+
+	return ""
+}
+
+func detectGitInfo(cwd string) (string, string) {
+	if cwd == "unknown" || cwd == "" {
+		return "", ""
+	}
+
+	searchDir := cwd
+	for searchDir != "/" && searchDir != "." && searchDir != "" {
+		gitDir := searchDir + "/.git"
+		if fi, err := os.Stat(gitDir); err == nil && fi.IsDir() {
+			// Repo name is the base dir
+			parts := strings.Split(strings.TrimRight(searchDir, "/"), "/")
+			gitRepo := parts[len(parts)-1]
+
+			// Try to read HEAD for branch
+			gitBranch := ""
+			headFile := gitDir + "/HEAD"
+			if head, err := os.ReadFile(headFile); err == nil {
+				headStr := strings.TrimSpace(string(head))
+				if strings.HasPrefix(headStr, "ref: ") {
+					ref := strings.TrimPrefix(headStr, "ref: ")
+					refParts := strings.Split(ref, "/")
+					gitBranch = refParts[len(refParts)-1]
+				}
+			}
+
+			return gitRepo, gitBranch
+		}
+
+		// Move up one directory
+		idx := strings.LastIndex(searchDir, "/")
+		if idx <= 0 {
+			break
+		}
+		searchDir = searchDir[:idx]
+	}
+
+	return "", ""
+}
+
+// buildEnvForPS returns environment variables with LC_ALL=C and TZ=UTC,
+// removing any existing LC_ALL or TZ to ensure consistent output format.
+func buildEnvForPS() []string {
+	var env []string
+	for _, e := range os.Environ() {
+		if !strings.HasPrefix(e, "LC_ALL=") && !strings.HasPrefix(e, "TZ=") {
+			env = append(env, e)
+		}
+	}
+	env = append(env, "LC_ALL=C", "TZ=UTC")
+	return env
+}
+
+func checkResourceUsage(pid int, currentHealth string) string {
+	// Use ps to get CPU and memory usage
+	// FreeBSD syntax: ps -p <pid> -o pcpu -o rss
+	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "pcpu", "-o", "rss").Output()
+	if err != nil {
+		return currentHealth
+	}
+
+	// Skip header line
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) < 2 {
+		return currentHealth
+	}
+
+	fields := strings.Fields(lines[1])
+	if len(fields) < 2 {
+		return currentHealth
+	}
+
+	// Check CPU percentage
+	cpuPct, _ := strconv.ParseFloat(fields[0], 64)
+	if cpuPct > 90 {
+		return "high-cpu"
+	}
+
+	// Check RSS memory in KB
+	rssKB, _ := strconv.ParseFloat(fields[1], 64)
+	rssMB := rssKB / 1024
+	if rssMB > 1024 { // > 1GB
+		return "high-mem"
+	}
+
+	return currentHealth
+}
+
+func resolveDockerProxyContainer(cmdline string) string {
+	var containerIP string
+	parts := strings.Fields(cmdline)
+	for i, part := range parts {
+		if part == "-container-ip" && i+1 < len(parts) {
+			containerIP = parts[i+1]
+			break
+		}
+	}
+	if containerIP == "" {
+		return ""
+	}
+
+	out, err := exec.Command("docker", "network", "inspect", "bridge",
+		"--format", "{{range .Containers}}{{.Name}}:{{.IPv4Address}}{{\"\\n\"}}{{end}}").Output()
+	if err != nil {
+		return ""
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		colonIdx := strings.Index(line, ":")
+		if colonIdx == -1 {
+			continue
+		}
+		name := line[:colonIdx]
+		ip := strings.Split(line[colonIdx+1:], "/")[0]
+		if ip == containerIP {
+			return "target: " + name
+		}
+	}
+	return ""
+}

--- a/internal/proc/resource_freebsd.go
+++ b/internal/proc/resource_freebsd.go
@@ -1,0 +1,14 @@
+//go:build freebsd
+
+package proc
+
+import "github.com/pranshuparmar/witr/pkg/model"
+
+// GetResourceContext returns resource usage context for a process
+// FreeBSD implementation - basic support
+func GetResourceContext(pid int) *model.ResourceContext {
+	// FreeBSD doesn't have macOS-style power assertions or thermal monitoring
+	// Could potentially check CPU temperature via sysctl dev.cpu.*.temperature
+	// but this is not process-specific
+	return nil
+}

--- a/internal/proc/socketstate_freebsd.go
+++ b/internal/proc/socketstate_freebsd.go
@@ -1,0 +1,148 @@
+//go:build freebsd
+
+package proc
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/pranshuparmar/witr/pkg/model"
+)
+
+// GetSocketStates returns all socket states for a given port
+func GetSocketStates(port int) ([]model.SocketInfo, error) {
+	var sockets []model.SocketInfo
+
+	// Use netstat to get all socket states (not just LISTEN)
+	// netstat -an -p tcp shows all TCP connections with states
+	out, err := exec.Command("netstat", "-an", "-p", "tcp").Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get socket states: %w", err)
+	}
+
+	portSuffix := fmt.Sprintf(".%d", port)
+	portColonSuffix := fmt.Sprintf(":%d", port)
+
+	for line := range strings.Lines(string(out)) {
+		fields := strings.Fields(line)
+		if len(fields) < 6 {
+			continue
+		}
+
+		// Check if this line mentions our port
+		localAddr := fields[3]
+		if !strings.HasSuffix(localAddr, portSuffix) && !strings.HasSuffix(localAddr, portColonSuffix) {
+			continue
+		}
+
+		// Parse the state (field 5)
+		state := fields[5]
+		remoteAddr := fields[4]
+
+		// Parse local address
+		address, _ := parseSockstatAddr(localAddr)
+
+		info := model.SocketInfo{
+			Port:       port,
+			State:      state,
+			LocalAddr:  address,
+			RemoteAddr: remoteAddr,
+		}
+
+		// Add explanation and workaround based on state
+		addStateExplanation(&info)
+
+		sockets = append(sockets, info)
+	}
+
+	return sockets, nil
+}
+
+// GetSocketStateForPort returns the most relevant socket state for a port
+// Prioritizes non-LISTEN states that explain why a port might be unavailable
+func GetSocketStateForPort(port int) *model.SocketInfo {
+	states, err := GetSocketStates(port)
+	if err != nil || len(states) == 0 {
+		return nil
+	}
+
+	// Prioritize problematic states
+	for _, s := range states {
+		if s.State == "TIME_WAIT" || s.State == "CLOSE_WAIT" || s.State == "FIN_WAIT_1" || s.State == "FIN_WAIT_2" {
+			return &s
+		}
+	}
+
+	// Return LISTEN if that's all we have
+	for _, s := range states {
+		if s.State == "LISTEN" {
+			return &s
+		}
+	}
+
+	// Return first state found
+	if len(states) > 0 {
+		return &states[0]
+	}
+
+	return nil
+}
+
+// addStateExplanation adds human-readable explanation for socket states
+func addStateExplanation(info *model.SocketInfo) {
+	switch info.State {
+	case "LISTEN":
+		info.Explanation = "Actively listening for connections"
+
+	case "TIME_WAIT":
+		info.Explanation = "Connection closed, waiting for delayed packets (default 60s on FreeBSD)"
+		info.Workaround = "Wait for timeout to expire, or use SO_REUSEADDR in your server"
+
+	case "CLOSE_WAIT":
+		info.Explanation = "Remote side closed connection, local side has not closed yet"
+		info.Workaround = "The application should call close() on the socket"
+
+	case "FIN_WAIT_1":
+		info.Explanation = "Local side initiated close, waiting for acknowledgment"
+
+	case "FIN_WAIT_2":
+		info.Explanation = "Local close acknowledged, waiting for remote close"
+
+	case "ESTABLISHED":
+		info.Explanation = "Active connection"
+
+	case "SYN_SENT":
+		info.Explanation = "Connection request sent, waiting for response"
+
+	case "SYN_RECEIVED":
+		info.Explanation = "Connection request received, sending acknowledgment"
+
+	case "CLOSING":
+		info.Explanation = "Both sides initiated close simultaneously"
+
+	case "LAST_ACK":
+		info.Explanation = "Waiting for final acknowledgment of close"
+
+	default:
+		info.Explanation = "Socket in " + info.State + " state"
+	}
+}
+
+// GetMSLDuration returns the Maximum Segment Lifetime setting
+// This determines TIME_WAIT duration (2 * MSL)
+func GetMSLDuration() int {
+	// Try to read from sysctl
+	out, err := exec.Command("sysctl", "-n", "net.inet.tcp.msl").Output()
+	if err != nil {
+		return 30000 // Default 30 seconds in milliseconds
+	}
+
+	msl, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return 30000
+	}
+
+	return msl
+}

--- a/internal/proc/user_freebsd.go
+++ b/internal/proc/user_freebsd.go
@@ -1,0 +1,33 @@
+//go:build freebsd
+
+package proc
+
+import (
+	"os/user"
+	"strconv"
+)
+
+func readUser(pid int) string {
+	// On FreeBSD, we get the UID from ps in ReadProcess and resolve it here
+	// This function is a fallback that just returns unknown
+	return "unknown"
+}
+
+func readUserByUID(uid int) string {
+	return resolveUID(uid)
+}
+
+func resolveUID(uid int) string {
+	if uid == 0 {
+		return "root"
+	}
+
+	// Try to resolve username using os/user package (works on FreeBSD)
+	u, err := user.LookupId(strconv.Itoa(uid))
+	if err == nil {
+		return u.Username
+	}
+
+	// Fallback to UID as string
+	return strconv.Itoa(uid)
+}

--- a/internal/source/launchd_freebsd.go
+++ b/internal/source/launchd_freebsd.go
@@ -1,0 +1,10 @@
+//go:build freebsd
+
+package source
+
+import "github.com/pranshuparmar/witr/pkg/model"
+
+func detectLaunchd(_ []model.Process) *model.Source {
+	// FreeBSD doesn't use launchd
+	return nil
+}

--- a/internal/source/systemd_freebsd.go
+++ b/internal/source/systemd_freebsd.go
@@ -1,0 +1,10 @@
+//go:build freebsd
+
+package source
+
+import "github.com/pranshuparmar/witr/pkg/model"
+
+func detectSystemd(_ []model.Process) *model.Source {
+	// FreeBSD doesn't use systemd
+	return nil
+}

--- a/internal/target/port_freebsd.go
+++ b/internal/target/port_freebsd.go
@@ -1,0 +1,142 @@
+//go:build freebsd
+
+package target
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func ResolvePort(port int) ([]int, error) {
+	// Use sockstat to find the process listening on this port
+	// sockstat -4 -l -P tcp -p <port>
+	// sockstat -6 -l -P tcp -p <port>
+	pidSet := make(map[int]bool)
+
+	for _, flag := range []string{"-4", "-6"} {
+		out, err := exec.Command("sockstat", flag, "-l", "-P", "tcp", "-p", strconv.Itoa(port)).Output()
+		if err != nil {
+			continue
+		}
+
+		// Parse sockstat output
+		// USER     COMMAND    PID   FD PROTO  LOCAL ADDRESS         FOREIGN ADDRESS
+		// root     nginx      1234  6  tcp4   *:80                  *:*
+		for line := range strings.Lines(string(out)) {
+			fields := strings.Fields(line)
+			if len(fields) < 6 {
+				continue
+			}
+
+			// Skip header
+			if fields[0] == "USER" {
+				continue
+			}
+
+			pid, err := strconv.Atoi(fields[2])
+			if err == nil && pid > 0 {
+				pidSet[pid] = true
+			}
+		}
+	}
+
+	if len(pidSet) == 0 {
+		// Try netstat as fallback
+		return resolvePortNetstat(port)
+	}
+
+	// Return the lowest PID (the main listener, not forked children)
+	var result []int
+	minPID := 0
+	for pid := range pidSet {
+		if minPID == 0 || pid < minPID {
+			minPID = pid
+		}
+	}
+	if minPID > 0 {
+		result = append(result, minPID)
+	}
+
+	if len(result) == 0 {
+		return nil, fmt.Errorf("socket found but owning process not detected")
+	}
+
+	return result, nil
+}
+
+func resolvePortNetstat(port int) ([]int, error) {
+	// Fallback using netstat
+	// On FreeBSD: netstat -an -p tcp | grep LISTEN
+	out, err := exec.Command("netstat", "-an", "-p", "tcp").Output()
+	if err != nil {
+		return nil, fmt.Errorf("no process listening on port %d", port)
+	}
+
+	portStr := fmt.Sprintf(".%d", port)
+	portColonStr := fmt.Sprintf(":%d", port)
+
+	for line := range strings.Lines(string(out)) {
+		if !strings.Contains(line, "LISTEN") {
+			continue
+		}
+		if !strings.Contains(line, portStr) && !strings.Contains(line, portColonStr) {
+			continue
+		}
+
+		// Unfortunately, basic netstat doesn't show PID on FreeBSD
+		// We need to use sockstat or fstat for that
+		// Try fstat as last resort
+		return resolvePortFstat(port)
+	}
+
+	return nil, fmt.Errorf("no process listening on port %d", port)
+}
+
+func resolvePortFstat(port int) ([]int, error) {
+	// Use fstat to find processes with open sockets
+	// This is less efficient but works as a fallback
+	out, err := exec.Command("fstat").Output()
+	if err != nil {
+		return nil, fmt.Errorf("no process listening on port %d", port)
+	}
+
+	portStr := fmt.Sprintf(":%d", port)
+	pidSet := make(map[int]bool)
+
+	for line := range strings.Lines(string(out)) {
+		if !strings.Contains(line, "tcp") {
+			continue
+		}
+		if !strings.Contains(line, portStr) {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) >= 3 {
+			pid, err := strconv.Atoi(fields[2])
+			if err == nil && pid > 0 {
+				pidSet[pid] = true
+			}
+		}
+	}
+
+	if len(pidSet) == 0 {
+		return nil, fmt.Errorf("no process listening on port %d", port)
+	}
+
+	// Return the lowest PID
+	var result []int
+	minPID := 0
+	for pid := range pidSet {
+		if minPID == 0 || pid < minPID {
+			minPID = pid
+		}
+	}
+	if minPID > 0 {
+		result = append(result, minPID)
+	}
+
+	return result, nil
+}

--- a/internal/tools/docgen/main.go
+++ b/internal/tools/docgen/main.go
@@ -1,4 +1,4 @@
-//go:build linux || darwin
+//go:build linux || darwin || freebsd
 
 package main
 


### PR DESCRIPTION
Add platform-specific implementations for FreeBSD, following the same patterns used for Linux and macOS.

New files:
- internal/proc/*_freebsd.go: Process info, network sockets, boot time, user resolution, file descriptors, command line, file context, resource context, and socket state implementations
- internal/target/*_freebsd.go: Port and name resolution using sockstat and ps commands
- internal/source/*_freebsd.go: Stubs for systemd/launchd detection

FreeBSD-specific implementation details:
- Use ps(1) with FreeBSD syntax (-o pid -o ppid, not -o pid=,ppid=)
- Skip header lines in ps output (FreeBSD always outputs headers)
- Use sockstat(1) for network socket enumeration
- Use fstat(1) for file descriptor information
- Detect FreeBSD jails as container type
- Detect rc.d services via /var/run/*.pid files

Updated files:
- cmd/root.go, cmd/witr/main.go, cmd/witr/unsupported.go: Add freebsd build tag
- internal/tools/docgen/main.go: Add freebsd build tag
- .goreleaser.yml: Add freebsd to build targets
- install.sh: Add FreeBSD OS detection