### PR TITLE
feat: add --verbose flag for extended process information

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,6 +69,9 @@ func _genExamples() string {
   # Output machine-readable JSON
   witr chrome --json
 
+  # Show extended process information (memory, I/O, file descriptors)
+  witr mysql --verbose
+
   # Combine flags: inspect port, show environment variables, output JSON
   witr --port 8080 --env --json
 `
@@ -107,6 +110,7 @@ func init() {
 	rootCmd.Flags().Bool("warnings", false, "show only warnings")
 	rootCmd.Flags().Bool("no-color", false, "disable colorized output")
 	rootCmd.Flags().Bool("env", false, "show environment variables for the process")
+	rootCmd.Flags().Bool("verbose", false, "show extended process information")
 
 }
 
@@ -124,6 +128,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	jsonFlag, _ := cmd.Flags().GetBool("json")
 	warnFlag, _ := cmd.Flags().GetBool("warnings")
 	noColorFlag, _ := cmd.Flags().GetBool("no-color")
+	verboseFlag, _ := cmd.Flags().GetBool("verbose")
 
 	if envFlag {
 		var t model.Target
@@ -269,7 +274,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	} else if shortFlag {
 		output.RenderShort(res, !noColorFlag)
 	} else {
-		output.RenderStandard(res, !noColorFlag)
+		output.RenderStandard(res, !noColorFlag, verboseFlag)
 	}
 	return nil
 }

--- a/internal/output/standard.go
+++ b/internal/output/standard.go
@@ -55,7 +55,7 @@ func RenderWarnings(warnings []string, colorEnabled bool) {
 	}
 }
 
-func RenderStandard(r model.Result, colorEnabled bool) {
+func RenderStandard(r model.Result, colorEnabled bool, verbose bool) {
 	// Target
 	target := "unknown"
 	if len(r.Ancestry) > 0 {
@@ -359,6 +359,115 @@ func RenderStandard(r model.Result, colorEnabled bool) {
 			fmt.Println("\nWarnings    :")
 			for _, w := range r.Warnings {
 				fmt.Printf("  • %s\n", w)
+			}
+		}
+	}
+
+	// Extended information for verbose mode
+	if verbose {
+		if colorEnabled {
+			fmt.Printf("\n%sExtended Information%s:\n", colorMagenta, colorReset)
+		} else {
+			fmt.Println("\nExtended Information:")
+		}
+
+		// Memory information
+		if proc.Memory.VMS > 0 {
+			if colorEnabled {
+				fmt.Printf("\n%sMemory%s:\n", colorGreen, colorReset)
+				fmt.Printf("  Virtual: %.1f MB\n", proc.Memory.VMSMB)
+				fmt.Printf("  Resident: %.1f MB\n", proc.Memory.RSSMB)
+				if proc.Memory.Shared > 0 {
+					fmt.Printf("  Shared: %.1f MB\n", float64(proc.Memory.Shared)/(1024*1024))
+				}
+			} else {
+				fmt.Printf("\nMemory:\n")
+				fmt.Printf("  Virtual: %.1f MB\n", proc.Memory.VMSMB)
+				fmt.Printf("  Resident: %.1f MB\n", proc.Memory.RSSMB)
+				if proc.Memory.Shared > 0 {
+					fmt.Printf("  Shared: %.1f MB\n", float64(proc.Memory.Shared)/(1024*1024))
+				}
+			}
+		}
+
+		// I/O statistics
+		if proc.IO.ReadBytes > 0 || proc.IO.WriteBytes > 0 {
+			if colorEnabled {
+				fmt.Printf("\n%sI/O Statistics%s:\n", colorGreen, colorReset)
+				if proc.IO.ReadBytes > 0 {
+					fmt.Printf("  Read: %.1f MB (%d ops)\n", float64(proc.IO.ReadBytes)/(1024*1024), proc.IO.ReadOps)
+				}
+				if proc.IO.WriteBytes > 0 {
+					fmt.Printf("  Write: %.1f MB (%d ops)\n", float64(proc.IO.WriteBytes)/(1024*1024), proc.IO.WriteOps)
+				}
+			} else {
+				fmt.Printf("\nI/O Statistics:\n")
+				if proc.IO.ReadBytes > 0 {
+					fmt.Printf("  Read: %.1f MB (%d ops)\n", float64(proc.IO.ReadBytes)/(1024*1024), proc.IO.ReadOps)
+				}
+				if proc.IO.WriteBytes > 0 {
+					fmt.Printf("  Write: %.1f MB (%d ops)\n", float64(proc.IO.WriteBytes)/(1024*1024), proc.IO.WriteOps)
+				}
+			}
+		}
+
+		// File descriptors
+		if proc.FDCount > 0 {
+			if colorEnabled {
+				if proc.FDLimit == 0 {
+					fmt.Printf("\n%sFile Descriptors%s: %d/unlimited\n", colorGreen, colorReset, proc.FDCount)
+				} else {
+					fmt.Printf("\n%sFile Descriptors%s: %d/%d\n", colorGreen, colorReset, proc.FDCount, proc.FDLimit)
+				}
+				if len(proc.FileDescs) > 0 && len(proc.FileDescs) <= 10 {
+					for _, fd := range proc.FileDescs {
+						fmt.Printf("  %s\n", fd)
+					}
+				} else if len(proc.FileDescs) > 10 {
+					fmt.Printf("  Showing first 10 of %d descriptors:\n", len(proc.FileDescs))
+					for i := 0; i < 10; i++ {
+						fmt.Printf("  %s\n", proc.FileDescs[i])
+					}
+					fmt.Printf("  ... and %d more\n", len(proc.FileDescs)-10)
+				}
+			} else {
+				if proc.FDLimit == 0 {
+					fmt.Printf("\nFile Descriptors: %d/unlimited\n", proc.FDCount)
+				} else {
+					fmt.Printf("\nFile Descriptors: %d/%d\n", proc.FDCount, proc.FDLimit)
+				}
+				if len(proc.FileDescs) > 0 && len(proc.FileDescs) <= 10 {
+					for _, fd := range proc.FileDescs {
+						fmt.Printf("  %s\n", fd)
+					}
+				} else if len(proc.FileDescs) > 10 {
+					fmt.Printf("  Showing first 10 of %d descriptors:\n", len(proc.FileDescs))
+					for i := 0; i < 10; i++ {
+						fmt.Printf("  %s\n", proc.FileDescs[i])
+					}
+					fmt.Printf("  ... and %d more\n", len(proc.FileDescs)-10)
+				}
+			}
+		}
+
+		// Children and threads
+		if proc.ThreadCount > 1 || len(proc.Children) > 0 {
+			if colorEnabled {
+				fmt.Printf("\n%sProcess Details%s:\n", colorGreen, colorReset)
+				if proc.ThreadCount > 1 {
+					fmt.Printf("  Threads: %d\n", proc.ThreadCount)
+				}
+				if len(proc.Children) > 0 {
+					fmt.Printf("  Children: %v\n", proc.Children)
+				}
+			} else {
+				fmt.Printf("\nProcess Details:\n")
+				if proc.ThreadCount > 1 {
+					fmt.Printf("  Threads: %d\n", proc.ThreadCount)
+				}
+				if len(proc.Children) > 0 {
+					fmt.Printf("  Children: %v\n", proc.Children)
+				}
 			}
 		}
 	}

--- a/internal/proc/extended_linux.go
+++ b/internal/proc/extended_linux.go
@@ -1,0 +1,135 @@
+//go:build linux
+
+package proc
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/pranshuparmar/witr/pkg/model"
+)
+
+// ReadExtendedInfo reads extended process information for verbose output
+func ReadExtendedInfo(pid int) (model.MemoryInfo, model.IOStats, []string, int, uint64, []int, int, error) {
+	var memInfo model.MemoryInfo
+	var ioStats model.IOStats
+	var fileDescs []string
+	var children []int
+	var threadCount int
+	fdCount := 0
+	var fdLimit uint64
+
+	// Read memory info from /proc/[pid]/statm
+	if statmData, err := os.ReadFile(fmt.Sprintf("/proc/%d/statm", pid)); err == nil {
+		fields := strings.Fields(string(statmData))
+		if len(fields) >= 7 {
+			pageSize := uint64(os.Getpagesize())
+
+			// statm fields: total resident shared text lib data dirty
+			total, _ := strconv.ParseUint(fields[0], 10, 64)
+			resident, _ := strconv.ParseUint(fields[1], 10, 64)
+			shared, _ := strconv.ParseUint(fields[2], 10, 64)
+			text, _ := strconv.ParseUint(fields[3], 10, 64)
+			lib, _ := strconv.ParseUint(fields[4], 10, 64)
+			data, _ := strconv.ParseUint(fields[5], 10, 64)
+			dirty, _ := strconv.ParseUint(fields[6], 10, 64)
+
+			memInfo = model.MemoryInfo{
+				VMS:    total * pageSize,
+				RSS:    resident * pageSize,
+				VMSMB:  float64(total*pageSize) / (1024 * 1024),
+				RSSMB:  float64(resident*pageSize) / (1024 * 1024),
+				Shared: shared * pageSize,
+				Text:   text * pageSize,
+				Lib:    lib * pageSize,
+				Data:   data * pageSize,
+				Dirty:  dirty * pageSize,
+			}
+		}
+	}
+
+	// Read I/O stats from /proc/[pid]/io
+	if ioData, err := os.ReadFile(fmt.Sprintf("/proc/%d/io", pid)); err == nil {
+		lines := strings.Split(string(ioData), "\n")
+		for _, line := range lines {
+			if strings.HasPrefix(line, "read_bytes:") {
+				if val, err := strconv.ParseUint(strings.TrimSpace(strings.TrimPrefix(line, "read_bytes:")), 10, 64); err == nil {
+					ioStats.ReadBytes = val
+				}
+			} else if strings.HasPrefix(line, "write_bytes:") {
+				if val, err := strconv.ParseUint(strings.TrimSpace(strings.TrimPrefix(line, "write_bytes:")), 10, 64); err == nil {
+					ioStats.WriteBytes = val
+				}
+			} else if strings.HasPrefix(line, "syscr:") {
+				if val, err := strconv.ParseUint(strings.TrimSpace(strings.TrimPrefix(line, "syscr:")), 10, 64); err == nil {
+					ioStats.ReadOps = val
+				}
+			} else if strings.HasPrefix(line, "syscw:") {
+				if val, err := strconv.ParseUint(strings.TrimSpace(strings.TrimPrefix(line, "syscw:")), 10, 64); err == nil {
+					ioStats.WriteOps = val
+				}
+			}
+		}
+	}
+
+	// Read file descriptors from /proc/[pid]/fd
+	if fdDir, err := os.ReadDir(fmt.Sprintf("/proc/%d/fd", pid)); err == nil {
+		fdCount = len(fdDir)
+		for _, fdEntry := range fdDir {
+			fdPath := fmt.Sprintf("/proc/%d/fd/%s", pid, fdEntry.Name())
+			if linkTarget, err := os.Readlink(fdPath); err == nil {
+				fileDescs = append(fileDescs, fmt.Sprintf("%s -> %s", fdEntry.Name(), linkTarget))
+			}
+		}
+	}
+
+	// Get file descriptor limit
+	if limitsData, err := os.ReadFile(fmt.Sprintf("/proc/%d/limits", pid)); err == nil {
+		lines := strings.Split(string(limitsData), "\n")
+		for _, line := range lines {
+			if strings.Contains(line, "Max open files") {
+				fields := strings.Fields(line)
+				if len(fields) >= 2 {
+					if limit, err := strconv.ParseUint(strings.ReplaceAll(fields[1], "-", "0"), 10, 64); err == nil {
+						fdLimit = limit
+					}
+				}
+				break
+			}
+		}
+	}
+
+	// Find child processes
+	if procEntries, err := os.ReadDir("/proc"); err == nil {
+		for _, entry := range procEntries {
+			if childPID, err := strconv.Atoi(entry.Name()); err == nil {
+				if statData, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", childPID)); err == nil {
+					fields := strings.Fields(string(statData))
+					if len(fields) > 3 {
+						ppid, _ := strconv.Atoi(fields[3])
+						if ppid == pid {
+							children = append(children, childPID)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Get thread count from /proc/[pid]/status
+	if statusData, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid)); err == nil {
+		lines := strings.Split(string(statusData), "\n")
+		for _, line := range lines {
+			if strings.HasPrefix(line, "Threads:") {
+				if count, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(line, "Threads:"))); err == nil {
+					threadCount = count
+				}
+				break
+			}
+		}
+	}
+
+	return memInfo, ioStats, fileDescs, fdCount, fdLimit, children, threadCount, nil
+}

--- a/internal/proc/process_linux.go
+++ b/internal/proc/process_linux.go
@@ -220,6 +220,9 @@ func ReadProcess(pid int) (model.Process, error) {
 		container = resolveDockerProxyContainer(cmdline)
 	}
 
+	// Read extended information
+	memInfo, ioStats, fileDescs, fdCount, fdLimit, children, threadCount, _ := ReadExtendedInfo(pid)
+
 	return model.Process{
 		PID:            pid,
 		PPID:           ppid,
@@ -237,6 +240,13 @@ func ReadProcess(pid int) (model.Process, error) {
 		Health:         health,
 		Forked:         forked,
 		Env:            env,
+		Memory:         memInfo,
+		IO:             ioStats,
+		FileDescs:      fileDescs,
+		FDCount:        fdCount,
+		FDLimit:        fdLimit,
+		Children:       children,
+		ThreadCount:    threadCount,
 	}, nil
 }
 

--- a/pkg/model/process.go
+++ b/pkg/model/process.go
@@ -28,4 +28,34 @@ type Process struct {
 	Forked string
 	// Environment variables (key=value)
 	Env []string
+
+	// Extended information for verbose output
+	Memory      MemoryInfo `json:",omitempty"`
+	IO          IOStats    `json:",omitempty"`
+	FileDescs   []string   `json:",omitempty"`
+	FDCount     int        `json:",omitempty"`
+	FDLimit     uint64     `json:",omitempty"`
+	Children    []int      `json:",omitempty"`
+	ThreadCount int        `json:",omitempty"`
+}
+
+// MemoryInfo contains detailed memory information
+type MemoryInfo struct {
+	VMS    uint64  // Virtual memory size in bytes
+	RSS    uint64  // Resident set size in bytes
+	VMSMB  float64 // Virtual memory in MB
+	RSSMB  float64 // Resident memory in MB
+	Shared uint64  // Shared memory size in bytes
+	Text   uint64  // Code size in bytes
+	Lib    uint64  // Library size in bytes
+	Data   uint64  // Data + stack size in bytes
+	Dirty  uint64  // Dirty pages size in bytes
+}
+
+// IOStats contains I/O statistics
+type IOStats struct {
+	ReadBytes  uint64 // Bytes read from storage
+	WriteBytes uint64 // Bytes written to storage
+	ReadOps    uint64 // Number of read operations
+	WriteOps   uint64 // Number of write operations
 }


### PR DESCRIPTION
- Add MemoryInfo and IOStats structs to model
- Extend Process struct with memory, I/O, file descriptors, children, and thread fields
- Implement ReadExtendedInfo in extended_linux.go to read /proc data
- Update ReadProcess to populate extended fields
- Modify RenderStandard to display extended info when verbose=true
- Add --verbose flag to CLI with example in help
- Fix file descriptor limit display to show 'unlimited' for unlimited cases