### PR TITLE
docs: Add SECURITY.md policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Supported Versions
+
+We currently support the following versions of **witr** with security updates:              |
+
+| Feature | Supported |
+| ------- | --------- |
+| macOS   | :white_check_mark: |
+| Linux   | :white_check_mark: |
+| Windows | :x: |
+
+See our [Feature Compatibility Matrix](README.md#91-feature-compatibility-matrix) for more details.
+
+## Reporting a Vulnerability
+
+We take the security of **witr** seriously. If you believe you have found a security vulnerability, please report it to us responsibly.
+
+### What to include in your report
+
+To help us understand and resolve the issue quickly, please include as much information as possible:
+
+- A description of the vulnerability.
+- Steps to reproduce the issue (including any sample code or configuration).
+- Potential impact of the vulnerability.
+- Any suggested mitigations or fixes.
+
+## Our Response Process
+
+1. **Acknowledgment**: We will acknowledge receipt of your report within 48 hours.
+2. **Investigation**: We will investigate the report and determine the severity and impact.
+3. **Fix**: If a vulnerability is confirmed, we will work on a fix and release a new version as soon as possible.
+4. **Disclosure**: We will coordinate the disclosure of the vulnerability with you to ensure that users have time to update.
+
+## Attribution
+
+This security policy is based on standard open-source practices.


### PR DESCRIPTION
## Description
This PR adds a [SECURITY.md](cci:7://file:///Users/someshchoudhary/Documents/Projects/witr/SECURITY.md:0:0-0:0) file to the repository to clearly define the project's security policy.

## Description
Adds [SECURITY.md](cci:7://file:///Users/someshchoudhary/Documents/Projects/witr/SECURITY.md:0:0-0:0).

## Context
Ported from branch `adding-code-of-cunduct` (Commit: 8f3a2b1).

## Changes
- Added [SECURITY.md](cci:7://file:///Users/someshchoudhary/Documents/Projects/witr/SECURITY.md:0:0-0:0) outlining:
  - Supported versions (macOS, Linux).
  - Vulnerability reporting process.
  - Response timeline and disclosure policy.

## Related Issue
- Addresses the need for a formal security policy.