### PR TITLE
Fix/fd limit parsing

### DIFF
--- a/internal/proc/extended_linux.go
+++ b/internal/proc/extended_linux.go
@@ -91,8 +91,10 @@ func ReadExtendedInfo(pid int) (model.MemoryInfo, model.IOStats, []string, int, 
 		for _, line := range lines {
 			if strings.Contains(line, "Max open files") {
 				fields := strings.Fields(line)
-				if len(fields) >= 2 {
-					if limit, err := strconv.ParseUint(strings.ReplaceAll(fields[1], "-", "0"), 10, 64); err == nil {
+				if len(fields) >= 4 {
+					if fields[3] == "unlimited" {
+						fdLimit = 0
+					} else if limit, err := strconv.ParseUint(fields[3], 10, 64); err == nil {
 						fdLimit = limit
 					}
 				}


### PR DESCRIPTION
`internal/proc/extended_linux.go` parses the `Max open files` line by reading `fields[1]`, which is the string `"open"`, not the numeric limit. Parsing fails and `fdLimit` stays `0`, so the output prints `.../unlimited`.

Now we read fields[3], guard the length, and map unlimited to 0 so the output is accurate.


Closes #118 