### PR TITLE
Fix/read process verbose

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -229,6 +229,20 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		resolvedTarget = proc.Command
 	}
 
+	if verboseFlag && len(ancestry) > 0 {
+		memInfo, ioStats, fileDescs, fdCount, fdLimit, children, threadCount, err := procpkg.ReadExtendedInfo(pid)
+		if err == nil {
+			proc.Memory = memInfo
+			proc.IO = ioStats
+			proc.FileDescs = fileDescs
+			proc.FDCount = fdCount
+			proc.FDLimit = fdLimit
+			proc.Children = children
+			proc.ThreadCount = threadCount
+			ancestry[len(ancestry)-1] = proc
+		}
+	}
+
 	// Calculate restart count (consecutive same-command entries)
 	restartCount := 0
 	lastCmd := ""

--- a/internal/proc/extended_darwin.go
+++ b/internal/proc/extended_darwin.go
@@ -1,0 +1,10 @@
+//go:build darwin
+
+package proc
+
+import "github.com/pranshuparmar/witr/pkg/model"
+
+// ReadExtendedInfo is a no-op on macOS; verbose extended info is Linux-only.
+func ReadExtendedInfo(pid int) (model.MemoryInfo, model.IOStats, []string, int, uint64, []int, int, error) {
+	return model.MemoryInfo{}, model.IOStats{}, nil, 0, 0, nil, 0, nil
+}

--- a/internal/proc/process_linux.go
+++ b/internal/proc/process_linux.go
@@ -220,9 +220,6 @@ func ReadProcess(pid int) (model.Process, error) {
 		container = resolveDockerProxyContainer(cmdline)
 	}
 
-	// Read extended information
-	memInfo, ioStats, fileDescs, fdCount, fdLimit, children, threadCount, _ := ReadExtendedInfo(pid)
-
 	return model.Process{
 		PID:            pid,
 		PPID:           ppid,
@@ -240,13 +237,6 @@ func ReadProcess(pid int) (model.Process, error) {
 		Health:         health,
 		Forked:         forked,
 		Env:            env,
-		Memory:         memInfo,
-		IO:             ioStats,
-		FileDescs:      fileDescs,
-		FDCount:        fdCount,
-		FDLimit:        fdLimit,
-		Children:       children,
-		ThreadCount:    threadCount,
 	}, nil
 }
 


### PR DESCRIPTION
This PR fixes calling `ReadExtendedInfo` for every `ReadProcess` (including all ancestors) even when `--verbose` was off, which meant extra `/proc` scans and fd reads on normal runs.
Now we only collect extended info when `--verbose` is set, and only for the target PID.

I also added a small `extended_darwin.go` stub so the darwin build doesn’t break when `ReadExtendedInfo` is referenced.