### PR TITLE
Remove unnecessary branch logic judgments in resource_darwin.go

### DIFF
--- a/internal/proc/resource_darwin.go
+++ b/internal/proc/resource_darwin.go
@@ -106,9 +106,7 @@ func getThermalState() string {
 					case "2":
 						return "Heavy thermal pressure"
 					default:
-						if level != "0" {
-							return "Thermal pressure level " + level
-						}
+						return "Thermal pressure level " + level
 					}
 				}
 			}


### PR DESCRIPTION
hi, this is a small code optimization pr. i found an invalid `if` logic check on line 109 of the resource_darwin.go file, so I tried removing it.