### PR TITLE
Fix: sudo command usage in install.sh (introduced in 7ee5907)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -107,10 +107,10 @@ if [[ "$need_sudo" == "1" ]]; then
 fi
 
 # Install
-"${SUDO[@]}" install -m 755 "$TMP" "$INSTALL_PATH"
+${SUDO[@]+"${SUDO[@]}"} install -m 755 "$TMP" "$INSTALL_PATH"
 
 # Install man page
-"${SUDO[@]}" mkdir -p "$INSTALL_MAN_DIR"
-"${SUDO[@]}" install -m 644 "$MAN_TMP" "$MAN_PATH"
+${SUDO[@]+"${SUDO[@]}"} mkdir -p "$INSTALL_MAN_DIR"
+${SUDO[@]+"${SUDO[@]}"} install -m 644 "$MAN_TMP" "$MAN_PATH"
 echo "witr installed successfully to $INSTALL_PATH (version: $LATEST, os: $OS, arch: $ARCH)"
 echo "Man page installed to $MAN_PATH"


### PR DESCRIPTION
# Fix: unbound variable error when need_sudo=0

## Description

Fixes the `unbound variable` error that occurs when installing without sudo privileges on systems where the user already has write permissions to the installation directories.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have opened this PR against the `staging` branch
- [x] I have performed a self-review of my own code
- [x] I have added helpful comments where needed
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes


### Problem
The install script fails with `bash: line 110: SUDO[@]: unbound variable` when `need_sudo=0` (i.e., when the user has write permissions to the installation directories):

```bash
  > curl -fsSL https://raw.githubusercontent.com/pranshuparmar/witr/main/install.sh | bash

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 4634k  100 4634k    0     0  13.7M      0 --:--:-- --:--:-- --:--:-- 51.2M
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  1562  100  1562    0     0   7777      0 --:--:-- --:--:-- --:--:--  7777
bash: line 110: SUDO[@]: unbound variable
```

This was introduced in the [recent commit](https://github.com/pranshuparmar/witr/commit/7ee590762264b8af9ccd365bd9b4c837915689e7) (7ee5907) that added support for `sudo`/`doas`/`run0`. The issue occurs because:
1. The script uses `set -euo pipefail` (the `-u` flag treats unbound variables as errors)
2. When `need_sudo=0`, `SUDO=()` remains an empty array
3. Expanding `"${SUDO[@]}"` on an empty array triggers the unbound variable error

### Solution
Replace `"${SUDO[@]}"` with `${SUDO[@]+"${SUDO[@]}"}` in all three locations where it's used.

This parameter expansion syntax safely handles empty arrays:
- If `SUDO` is set and non-empty: expands to the array elements with proper quoting
- If `SUDO` is empty or unset: expands to nothing (no error)

### Changes
- Line 110: Install binary command
- Line 113: Create man directory command  
- Line 114: Install man page command

### Testing
Tested on a system where the user has write permissions to `/usr/local/bin` (no sudo needed) - the script now completes successfully without errors.

```bash
  > bash install.sh 

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 4634k  100 4634k    0     0  11.5M      0 --:--:-- --:--:-- --:--:-- 11.5M
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  1562  100  1562    0     0   5999      0 --:--:-- --:--:-- --:--:--  5999
witr installed successfully to /usr/local/bin/witr (version: v0.2.0, os: darwin, arch: amd64)
Man page installed to /usr/local/share/man/man1/witr.1
```