### PR TITLE
Only retrieve the pid in the LISTENING state on Windows

### DIFF
--- a/internal/target/port_windows.go
+++ b/internal/target/port_windows.go
@@ -27,6 +27,10 @@ func ResolvePort(port int) ([]int, error) {
 			if len(fields) < 5 {
 				continue
 			}
+			state := fields[3]
+			if state != "LISTENING" {
+				continue
+			}
 			// Proto Local Address Foreign Address State PID
 			localAddr := fields[1]
 			if strings.HasSuffix(localAddr, portStr) {


### PR DESCRIPTION
## Description

Briefly describe what this PR does. Mention existing issue number, if applicable.

## Type of change

Check all that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (may affect existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] I have formatted my code using `go fmt ./...`
- [x] I have opened this PR against the `staging` branch
- [x] I have performed a self-review of my own code
- [ ] I have added helpful comments where needed
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

The `port_linux.go` and `port_darwin.go` files only retrieved the PID of the listen state, but port_windows.go did not. therefore, i tried implementing it in Windows.
