### PR TITLE
fix: all binaries appear deleted on Darwin

### DIFF
--- a/internal/proc/process_darwin.go
+++ b/internal/proc/process_darwin.go
@@ -152,7 +152,7 @@ func isBinaryDeleted(pid int) bool {
 	path := ""
 	for line := range strings.Lines(string(out)) {
 		if len(line) > 1 && line[0] == 'n' {
-			path = line[1:]
+			path = strings.TrimSpace(line[1:])
 			break
 		}
 	}

--- a/internal/proc/process_darwin_test.go
+++ b/internal/proc/process_darwin_test.go
@@ -2,7 +2,12 @@
 
 package proc
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestDeriveDisplayCommand(t *testing.T) {
 	t.Parallel()
@@ -83,5 +88,39 @@ func TestExtractExecutableName(t *testing.T) {
 				t.Fatalf("extractExecutableName(%q) = %q, want %q", tt.cmdline, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestIsBinaryDeleted(t *testing.T) {
+	tmpDir := t.TempDir()
+	binPath := filepath.Join(tmpDir, "fakebin")
+	if err := os.WriteFile(binPath, []byte("ok"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	// Create a fake lsof command that just prints the binPath set above.
+	fakeBinDir := filepath.Join(tmpDir, "bin")
+	if err := os.Mkdir(fakeBinDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	lsofPath := filepath.Join(fakeBinDir, "lsof")
+	script := fmt.Sprintf("#!/bin/sh\nprintf 'p123\nn%s   \\n'", binPath)
+	if err := os.WriteFile(lsofPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write lsof script: %v", err)
+	}
+
+	// Add our fake lsof to the start of the PATH.
+	t.Setenv("PATH", fakeBinDir+":"+os.Getenv("PATH"))
+
+	if got := isBinaryDeleted(123); got {
+		t.Fatalf("isBinaryDeleted() = true, expected false")
+	}
+	if err := os.Remove(binPath); err != nil {
+		t.Fatalf("rm: %v", err)
+	}
+
+	if got := isBinaryDeleted(123); !got {
+		t.Fatalf("isBinaryDeleted() = false, expected true for deleted binary")
 	}
 }


### PR DESCRIPTION
## Description

Briefly describe what this PR does. Mention existing issue number, if applicable.

Fixes issue #154, which causes all binaries on Darwin to appear to be deleted.

The string we get from parsing `lsof` has a newline in it, so it doesn't match the actual name of the binary.

This change strips whitespace from the binary path, so it can be matched.

Add a unit test.

## Type of change

Check all that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (may affect existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] I have formatted my code using `go fmt ./...`
- [x] I have opened this PR against the `staging` branch
- [x] I have performed a self-review of my own code
- [x] I have added helpful comments where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Thank you for your contribution! 🎉

We’re excited to review your pull request. Please fill out the details above to help us understand your changes. Don’t worry if you can’t check every box, just do your best!
