### PR TITLE
perf: Change to the standard append to the end of the slice and perform a single reverse (Reverse) at the end in ancestry.go

### DIFF
--- a/internal/proc/ancestry.go
+++ b/internal/proc/ancestry.go
@@ -23,7 +23,7 @@ func ResolveAncestry(pid int) ([]model.Process, error) {
 			break
 		}
 
-		chain = append([]model.Process{p}, chain...)
+		chain = append(chain, p)
 
 		if p.PPID == 0 || p.PID == 1 {
 			break
@@ -33,6 +33,11 @@ func ResolveAncestry(pid int) ([]model.Process, error) {
 
 	if len(chain) == 0 {
 		return nil, fmt.Errorf("no process ancestry found")
+	}
+
+	// Reverse the chain to get root
+	for i, j := 0, len(chain)-1; i < j; i, j = i+1, j-1 {
+		chain[i], chain[j] = chain[j], chain[i]
 	}
 
 	return chain, nil


### PR DESCRIPTION



## Description

Briefly describe what this PR does. Mention existing issue number, if applicable.

## Type of change

Check all that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (may affect existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] I have formatted my code using `go fmt ./...`
- [x] I have opened this PR against the `staging` branch
- [x] I have performed a self-review of my own code
- [ ] I have added helpful comments where needed
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

the original code `chain = append([]model.Process{p}, chain...)` has a Time Complexity of N^2, while the time complexity of using the conventional append method is N. Although N is usually small, this approach aligns better with Go's idiomatic high-performance style

