### PR TITLE
perf: Merge commands for obtaining `Listening` information in darwin

### DIFF
--- a/internal/proc/fd_darwin.go
+++ b/internal/proc/fd_darwin.go
@@ -12,38 +12,40 @@ import (
 // On macOS, we use lsof to get this information
 func socketsForPID(pid int) []string {
 	var inodes []string
-
 	// Use lsof to find sockets for this PID
-	// -a = AND logic
-	// -p <pid> = specific process
 	// -i TCP = TCP sockets
+	// -s TCP:LISTEN = only in LISTEN state
 	// -n = don't resolve hostnames
 	// -P = don't resolve port names
-	out, err := exec.Command("lsof", "-a", "-p", strconv.Itoa(pid), "-i", "TCP", "-n", "-P", "-F", "n").Output()
+	out, err := exec.Command("lsof", "-i", "TCP", "-s", "TCP:LISTEN", "-n", "-P", "-F", "pn").Output()
 	if err != nil {
 		return inodes
 	}
 
 	// Parse lsof output
 	seen := make(map[string]bool)
-	for line := range strings.Lines(string(out)) {
-		if len(line) == 0 {
-			continue
-		}
-		if line[0] == 'n' {
-			// n<address>
-			addr := strings.TrimSpace(line[1:])
-			_, port := parseNetstatAddr(addr)
-			if port > 0 {
-				// Create pseudo-inode matching the format in readListeningSockets
-				inode := strconv.Itoa(pid) + ":" + strconv.Itoa(port)
-				if !seen[inode] {
-					seen[inode] = true
-					inodes = append(inodes, inode)
+	var blocks = strings.Split(string(out), "p")
+	for i := range blocks {
+		if strings.HasPrefix(blocks[i], strconv.Itoa(pid)+"\n") {
+			for line := range strings.Lines(blocks[i]) {
+				if len(line) == 0 {
+					continue
+				}
+				if line[0] == 'n' {
+					// n<address>
+					addr, port := parseNetstatAddr(strings.TrimSpace(line[1:]))
+					if port > 0 {
+						// Create pseudo-inode matching the format in readListeningSockets
+						inode := addr + ":" + strconv.Itoa(port)
+						if !seen[inode] {
+							seen[inode] = true
+							inodes = append(inodes, inode)
+						}
+					}
 				}
 			}
+			break
 		}
 	}
-
 	return inodes
 }

--- a/internal/proc/process_darwin.go
+++ b/internal/proc/process_darwin.go
@@ -100,17 +100,15 @@ func ReadProcess(pid int) (model.Process, error) {
 	gitRepo, gitBranch := detectGitInfo(cwd)
 
 	// Get listening ports for this process
-	sockets, _ := readListeningSockets()
 	inodes := socketsForPID(pid)
-
 	var ports []int
 	var addrs []string
 
 	for _, inode := range inodes {
-		if s, ok := sockets[inode]; ok {
-			ports = append(ports, s.Port)
-			addrs = append(addrs, s.Address)
-		}
+		var addrPort = strings.Split(inode, ":")
+		var port, _ = strconv.Atoi(addrPort[1])
+		ports = append(ports, port)
+		addrs = append(addrs, addrPort[0])
 	}
 
 	// Check for high resource usage


### PR DESCRIPTION
## Description

Briefly describe what this PR does. Mention existing issue number, if applicable.

## Type of change

Check all that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (may affect existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] I have formatted my code using `go fmt ./...`
- [x] I have opened this PR against the `staging` branch
- [x] I have performed a self-review of my own code
- [ ] I have added helpful comments where needed
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes


there are two similar commands in the `fd_darwin.go` and `net_darwin.go` files, both used to retrieve pid-related `addr` and `port`. i trying to merge them into a single command to improve performance. if this kind of command merging is allowed, i will continue searching for similar commands. thanks~