### PR TITLE
feat(proc): add Docker CLI fallback for port resolution

### DIFF
--- a/internal/output/docker.go
+++ b/internal/output/docker.go
@@ -1,0 +1,131 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/pranshuparmar/witr/pkg/model"
+)
+
+// dockerSourceLabel builds the source label from a DockerPortMatch.
+func dockerSourceLabel(match *model.DockerPortMatch) string {
+	if match.ComposeProject != "" && match.ComposeService != "" {
+		return fmt.Sprintf("docker-compose: %s/%s", match.ComposeProject, match.ComposeService)
+	}
+	return "docker"
+}
+
+// RenderDockerFallback renders Docker container info when /proc scanning fails
+// but a container was identified via Docker CLI.
+func RenderDockerFallback(w io.Writer, portValue string, match *model.DockerPortMatch, colorEnabled bool) {
+	out := NewPrinter(w)
+
+	name := SanitizeTerminal(match.Name)
+	image := SanitizeTerminal(match.Image)
+	ports := SanitizeTerminal(match.Ports)
+
+	// Target
+	if colorEnabled {
+		out.Printf("%sTarget%s      : port %s\n\n", ColorBlue, ColorReset, portValue)
+	} else {
+		out.Printf("Target      : port %s\n\n", portValue)
+	}
+
+	// Container
+	if colorEnabled {
+		out.Printf("%sContainer%s   : %s%s%s\n", ColorBlue, ColorReset, ColorGreen, ansiString(name), ColorReset)
+	} else {
+		out.Printf("Container   : %s\n", name)
+	}
+
+	// Image
+	if colorEnabled {
+		out.Printf("%sImage%s       : %s\n", ColorBlue, ColorReset, ansiString(image))
+	} else {
+		out.Printf("Image       : %s\n", image)
+	}
+
+	// Ports
+	if ports != "" {
+		if colorEnabled {
+			out.Printf("%sPorts%s       : %s\n", ColorBlue, ColorReset, ansiString(ports))
+		} else {
+			out.Printf("Ports       : %s\n", ports)
+		}
+	}
+
+	// Why It Exists
+	if colorEnabled {
+		out.Printf("\n%sWhy It Exists%s :\n  ", ColorMagenta, ColorReset)
+		out.Print("Docker Desktop (process not visible in current namespace)\n\n")
+	} else {
+		out.Printf("\nWhy It Exists :\n  ")
+		out.Print("Docker Desktop (process not visible in current namespace)\n\n")
+	}
+
+	// Source
+	sourceLabel := dockerSourceLabel(match)
+	if colorEnabled {
+		out.Printf("%sSource%s      : %s\n", ColorCyan, ColorReset, sourceLabel)
+	} else {
+		out.Printf("Source      : %s\n", sourceLabel)
+	}
+
+	// Note
+	if colorEnabled {
+		out.Printf("\n%sNote%s        : The owning process is not visible in this environment.\n", ColorDimYellow, ColorReset)
+		out.Printf("              This is common when Docker Desktop runs in a separate namespace\n")
+		out.Printf("              (e.g., WSL2 distro, macOS VM).\n")
+	} else {
+		out.Printf("\nNote        : The owning process is not visible in this environment.\n")
+		out.Printf("              This is common when Docker Desktop runs in a separate namespace\n")
+		out.Printf("              (e.g., WSL2 distro, macOS VM).\n")
+	}
+}
+
+// RenderDockerFallbackShort renders a single-line summary for --short mode.
+func RenderDockerFallbackShort(w io.Writer, portValue string, match *model.DockerPortMatch, colorEnabled bool) {
+	out := NewPrinter(w)
+	name := SanitizeTerminal(match.Name)
+	image := SanitizeTerminal(match.Image)
+
+	if colorEnabled {
+		out.Printf("port %s → %s%s%s (%s) [%s]\n", portValue, ColorGreen, ansiString(name), ColorReset, ansiString(image), dockerSourceLabel(match))
+	} else {
+		out.Printf("port %s → %s (%s) [%s]\n", portValue, name, image, dockerSourceLabel(match))
+	}
+}
+
+// DockerFallbackToJSON returns JSON output for a Docker fallback match.
+func DockerFallbackToJSON(portValue string, match *model.DockerPortMatch) (string, error) {
+	type dockerResult struct {
+		Target         string
+		ContainerID    string
+		ContainerName  string
+		Image          string
+		Ports          string `json:",omitempty"`
+		ComposeProject string `json:",omitempty"`
+		ComposeService string `json:",omitempty"`
+		Source         string
+		Note           string
+	}
+
+	res := dockerResult{
+		Target:         "port " + portValue,
+		ContainerID:    match.ID,
+		ContainerName:  match.Name,
+		Image:          match.Image,
+		Ports:          match.Ports,
+		ComposeProject: match.ComposeProject,
+		ComposeService: match.ComposeService,
+		Source:         dockerSourceLabel(match),
+		Note:           "The owning process is not visible in this environment. This is common when Docker Desktop runs in a separate namespace (e.g., WSL2 distro, macOS VM).",
+	}
+
+	data, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}

--- a/internal/output/docker_test.go
+++ b/internal/output/docker_test.go
@@ -1,0 +1,160 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/pranshuparmar/witr/pkg/model"
+)
+
+func TestRenderDockerFallback(t *testing.T) {
+	match := &model.DockerPortMatch{
+		ID:    "abc123",
+		Name:  "my-container",
+		Image: "nginx:latest",
+		Ports: "0.0.0.0:8080->80/tcp",
+	}
+
+	var buf bytes.Buffer
+	RenderDockerFallback(&buf, "8080", match, false)
+	out := buf.String()
+
+	expected := []string{
+		"Target      : port 8080",
+		"Container   : my-container",
+		"Image       : nginx:latest",
+		"Ports       : 0.0.0.0:8080->80/tcp",
+		"Why It Exists",
+		"Docker Desktop",
+		"Source      : docker",
+		"Note",
+	}
+
+	for _, want := range expected {
+		if !strings.Contains(out, want) {
+			t.Errorf("RenderDockerFallback output missing %q\nGot:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderDockerFallbackWithCompose(t *testing.T) {
+	match := &model.DockerPortMatch{
+		ID:             "abc123",
+		Name:           "myapp-db-1",
+		Image:          "postgres:16",
+		Ports:          "0.0.0.0:5432->5432/tcp",
+		ComposeProject: "myapp",
+		ComposeService: "db",
+	}
+
+	var buf bytes.Buffer
+	RenderDockerFallback(&buf, "5432", match, false)
+	out := buf.String()
+
+	if !strings.Contains(out, "docker-compose: myapp/db") {
+		t.Errorf("expected compose source label, got:\n%s", out)
+	}
+}
+
+func TestRenderDockerFallbackShort(t *testing.T) {
+	match := &model.DockerPortMatch{
+		ID:    "abc123",
+		Name:  "my-container",
+		Image: "nginx:latest",
+		Ports: "0.0.0.0:8080->80/tcp",
+	}
+
+	var buf bytes.Buffer
+	RenderDockerFallbackShort(&buf, "8080", match, false)
+	out := buf.String()
+
+	if !strings.Contains(out, "my-container") {
+		t.Errorf("short output missing container name, got: %s", out)
+	}
+	if !strings.Contains(out, "nginx:latest") {
+		t.Errorf("short output missing image, got: %s", out)
+	}
+	if !strings.Contains(out, "[docker]") {
+		t.Errorf("short output missing source, got: %s", out)
+	}
+	// Should be a single line
+	if strings.Count(out, "\n") != 1 {
+		t.Errorf("short output should be single line, got: %s", out)
+	}
+}
+
+func TestDockerFallbackToJSON(t *testing.T) {
+	match := &model.DockerPortMatch{
+		ID:             "abc123",
+		Name:           "sql-proxy",
+		Image:          "gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.13.0",
+		Ports:          "127.0.0.1:5432->5432/tcp",
+		ComposeProject: "",
+		ComposeService: "",
+	}
+
+	jsonStr, err := DockerFallbackToJSON("5432", match)
+	if err != nil {
+		t.Fatalf("DockerFallbackToJSON() error: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v", err)
+	}
+
+	if result["Target"] != "port 5432" {
+		t.Errorf("Target = %v, want %q", result["Target"], "port 5432")
+	}
+	if result["ContainerName"] != "sql-proxy" {
+		t.Errorf("ContainerName = %v, want %q", result["ContainerName"], "sql-proxy")
+	}
+	if result["Source"] != "docker" {
+		t.Errorf("Source = %v, want %q", result["Source"], "docker")
+	}
+}
+
+func TestDockerFallbackToJSONCompose(t *testing.T) {
+	match := &model.DockerPortMatch{
+		ID:             "def456",
+		Name:           "myapp-db-1",
+		Image:          "postgres:16",
+		Ports:          "0.0.0.0:5432->5432/tcp",
+		ComposeProject: "myapp",
+		ComposeService: "db",
+	}
+
+	jsonStr, err := DockerFallbackToJSON("5432", match)
+	if err != nil {
+		t.Fatalf("DockerFallbackToJSON() error: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v", err)
+	}
+
+	if result["Source"] != "docker-compose: myapp/db" {
+		t.Errorf("Source = %v, want %q", result["Source"], "docker-compose: myapp/db")
+	}
+}
+
+func TestRenderDockerFallbackSanitizesOutput(t *testing.T) {
+	// Simulate a malicious container name with ANSI escape sequence
+	match := &model.DockerPortMatch{
+		ID:    "abc123",
+		Name:  "evil\x1b[31mcontainer",
+		Image: "evil\x1b[0mimage",
+		Ports: "0.0.0.0:80->80/tcp",
+	}
+
+	var buf bytes.Buffer
+	RenderDockerFallback(&buf, "80", match, false)
+	out := buf.String()
+
+	if strings.Contains(out, "\x1b") {
+		t.Errorf("output contains raw ANSI escape sequences, sanitization failed:\n%s", out)
+	}
+}

--- a/internal/proc/container_test.go
+++ b/internal/proc/container_test.go
@@ -1,0 +1,71 @@
+package proc
+
+import (
+	"testing"
+)
+
+func TestSplitCmdline(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"simple", "docker ps", []string{"docker", "ps"}},
+		{"quoted", `docker inspect --format "{{.Name}}"`, []string{"docker", "inspect", "--format", "{{.Name}}"}},
+		{"empty", "", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitCmdline(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("splitCmdline(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("splitCmdline(%q)[%d] = %q, want %q", tt.in, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFindLongHexID(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"found", "/docker/" + "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2" + "/cgroup", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"},
+		{"not found", "no hex here", ""},
+		{"too short", "a1b2c3d4e5f6", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findLongHexID(tt.in)
+			if got != tt.want {
+				t.Fatalf("findLongHexID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractFlagValue(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmdline string
+		flags   []string
+		want    string
+	}{
+		{"found", "docker run --name myapp", []string{"--name"}, "myapp"},
+		{"not found", "docker run myapp", []string{"--name"}, ""},
+		{"at end", "docker run --name", []string{"--name"}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractFlagValue(tt.cmdline, tt.flags...)
+			if got != tt.want {
+				t.Fatalf("extractFlagValue() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/model/docker.go
+++ b/pkg/model/docker.go
@@ -1,0 +1,11 @@
+package model
+
+// DockerPortMatch holds information about a Docker container that publishes a specific port.
+type DockerPortMatch struct {
+	ID             string
+	Name           string
+	Image          string
+	Ports          string
+	ComposeProject string
+	ComposeService string
+}


### PR DESCRIPTION
## Description

When running `witr --port` in environments where Docker runs in a separate namespace (WSL2 with Docker Desktop, macOS VM), the port is visible in `/proc/net/tcp` but the owning process is not accessible via `/proc/<pid>/fd`. This results in "socket found but owning process not detected", even with `sudo`.

This PR adds a Docker CLI fallback: when `/proc` scanning fails for a port query, witr runs `docker ps --filter publish=<port>` to identify which container owns the port, and renders the container info (name, image, ports, compose project/service).

Closes #168

### Example output

```
Target      : port 5432

Container   : sql-proxy
Image       : gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.13.0
Ports       : 127.0.0.1:5432-5435->5432-5435/tcp

Why It Exists :
  Docker Desktop (process not visible in current namespace)

Source      : docker

Note        : The owning process is not visible in this environment.
              This is common when Docker Desktop runs in a separate namespace
              (e.g., WSL2 distro, macOS VM).
```

### Files changed

| File | Change |
|------|--------|
| `pkg/model/docker.go` | New `DockerPortMatch` struct in the model layer |
| `internal/proc/container.go` | New `ResolveContainerByPort()` with 3s timeout |
| `internal/proc/container_test.go` | Tests for existing container helpers |
| `internal/output/docker.go` | Dedicated renderers (standard, short, JSON) |
| `internal/output/docker_test.go` | Tests for rendering, JSON, and ANSI sanitization |
| `internal/app/app.go` | Wires Docker fallback into the error handler |

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (may affect existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] I have formatted my code using `go fmt ./...`
- [x] I have opened this PR against the `staging` branch
- [x] I have performed a self-review of my own code
- [x] I have added helpful comments where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Thank you for your contribution! 🎉