### PR TITLE
feat(tui): exit search mode on arrow key press

### DIFF
--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -470,11 +470,15 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						m.portInput.Blur()
 						return m, nil
 					}
-					var inputCmd tea.Cmd
-					m.portInput, inputCmd = m.portInput.Update(msg)
-					m.updatePortTable()
-					m.portTable.SetCursor(0)
-					return m, inputCmd
+					if msg.Type == tea.KeyUp || msg.Type == tea.KeyDown {
+						m.portInput.Blur()
+					} else {
+						var inputCmd tea.Cmd
+						m.portInput, inputCmd = m.portInput.Update(msg)
+						m.updatePortTable()
+						m.portTable.SetCursor(0)
+						return m, inputCmd
+					}
 				}
 
 				if msg.String() == "/" {
@@ -487,27 +491,31 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						m.input.Blur()
 						return m, nil
 					}
-					var inputCmd tea.Cmd
-					m.input, inputCmd = m.input.Update(msg)
-					m.filterProcesses()
-
-					m.table.SetCursor(0)
-					var treeCmd tea.Cmd
-					if len(m.filtered) > 0 {
-						selected := m.table.SelectedRow()
-						if len(selected) > 0 {
-							pid := 0
-							fmt.Sscanf(selected[0], "%d", &pid)
-							m.selectionID++
-							id := m.selectionID
-							treeCmd = tea.Tick(500*time.Millisecond, func(_ time.Time) tea.Msg {
-								return debounceMsg{id: id, pid: pid}
-							})
-						}
+					if msg.Type == tea.KeyUp || msg.Type == tea.KeyDown {
+						m.input.Blur()
 					} else {
-						m.treeViewport.SetContent("")
+						var inputCmd tea.Cmd
+						m.input, inputCmd = m.input.Update(msg)
+						m.filterProcesses()
+
+						m.table.SetCursor(0)
+						var treeCmd tea.Cmd
+						if len(m.filtered) > 0 {
+							selected := m.table.SelectedRow()
+							if len(selected) > 0 {
+								pid := 0
+								fmt.Sscanf(selected[0], "%d", &pid)
+								m.selectionID++
+								id := m.selectionID
+								treeCmd = tea.Tick(500*time.Millisecond, func(_ time.Time) tea.Msg {
+									return debounceMsg{id: id, pid: pid}
+								})
+							}
+						} else {
+							m.treeViewport.SetContent("")
+						}
+						return m, tea.Batch(inputCmd, treeCmd)
 					}
-					return m, tea.Batch(inputCmd, treeCmd)
 				}
 
 				if msg.String() == "/" {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -27,12 +27,12 @@ func (m MainModel) View() string {
 
 		if m.activeTab == tabPorts {
 			if m.portInput.Focused() {
-				status = "Mode: Searching (Press Esc/Enter to stop)"
+				status = "Mode: Searching (↑↓ to navigate, Esc/Enter to stop)"
 			}
 			inputView = m.portInput.View()
 		} else {
 			if m.input.Focused() {
-				status = "Mode: Searching (Press Esc/Enter to stop)"
+				status = "Mode: Searching (↑↓ to navigate, Esc/Enter to stop)"
 			}
 		}
 


### PR DESCRIPTION
## Description

Pressing ↑↓ arrow keys while searching now immediately navigates results without needing to press Esc/Enter first. It just felt more intuitive to me, but this PR maintains the original behaviour too.

I also adjusted the status message to reflect this change.

## Type of change

Check all that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (may affect existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] I have formatted my code using `go fmt ./...`
- [x] I have opened this PR against the `staging` branch
- [x] I have performed a self-review of my own code
- [ ] I have added helpful comments where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Thank you for your contribution! 🎉

We’re excited to review your pull request. Please fill out the details above to help us understand your changes. Don’t worry if you can’t check every box, just do your best!
