### PR TITLE
docs: add mise installation section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,11 +275,11 @@ You can install **witr** using [mise](https://mise.jdx.dev/):
 
 Latest version:
 ```bash
-mise use go:github.com/pranshuparmar/witr/cmd/witr
+mise use github:pranshuparmar/witr
 ```
 Specific version:
 ```bash
-mise use go:github.com/pranshuparmar/witr/cmd/witr@v.0.3.1
+mise use github:pranshuparmar/witr@v.0.3.1
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,22 @@ brioche install -r witr
 </details>
 
 <details>
+<summary><strong>Mise (macOS, Linux & Windows)</strong></summary>
+<br>
+
+You can install **witr** using [mise](https://mise.jdx.dev/):
+
+Latest version:
+```bash
+mise use go:github.com/pranshuparmar/witr/cmd/witr
+```
+Specific version:
+```bash
+mise use go:github.com/pranshuparmar/witr/cmd/witr@v.0.3.1
+```
+</details>
+
+<details>
 <summary><strong>Prebuilt Packages (deb, rpm, apk)</strong></summary>
 <br>
 


### PR DESCRIPTION
## Description

Adds a `mise` installation option to the README's package manager section (2.2).
`mise` supports macOS, Linux, and Windows and installs witr directly from Go source. 
Includes both latest-version and pinned-version install commands, styled consistently with the existing collapsible `<details>` blocks.

## Type of change

Check all that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (may affect existing functionality)
- [x] This change requires a documentation update

## Checklist

- [ ] I have formatted my code using `go fmt ./...`
- [x] I have opened this PR against the `staging` branch
- [x] I have performed a self-review of my own code
- [ ] I have added helpful comments where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
