### PR TITLE
docs(readme): fix Platform Support subsection numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,7 +663,7 @@ All target flags are repeatable and can be mixed. Results appear in the order yo
 
 ---
 
-### 5.1 Feature Compatibility Matrix
+### 6.1 Feature Compatibility Matrix
 
 | Feature | Linux | macOS | Windows | FreeBSD | Notes |
 |---------|:-----:|:-----:|:-------:|:-------:|-------|
@@ -711,7 +711,7 @@ All target flags are repeatable and can be mixed. Results appear in the order yo
 
 ---
 
-### 5.2 Permissions Note
+### 6.2 Permissions Note
 
 #### Linux/FreeBSD
 


### PR DESCRIPTION
## What

Renumber the two subsections under **6. Platform Support** in `README.md`:

- `### 5.1 Feature Compatibility Matrix` → `### 6.1 Feature Compatibility Matrix`
- `### 5.2 Permissions Note` → `### 6.2 Permissions Note`

## Why

Section 5 (Example Outputs) already defines subsections 5.1 through 5.6. The two subsections under Section 6 were mistakenly labeled 5.1 and 5.2, duplicating the numbering and breaking the otherwise consistent numeric outline used throughout the README (sections 2.x, 5.x, 9.x).

No cross-references in the README point to these subsections, so this is a label-only fix.

## How tested

- `grep -n "^###" README.md` confirms the rest of the document follows its parent section's numbering.
- `grep -n "5\.1\|5\.2\|6\.1\|6\.2" README.md` shows no other places reference these anchors, so no broken links.
- Visual diff is two lines.

> Drafted with AI assistance; verified by author before publishing.