### PR TITLE
feat(linux): detect incus/LXC containers via cgroup lxc.payload pattern

### DIFF
--- a/internal/proc/process_linux.go
+++ b/internal/proc/process_linux.go
@@ -119,11 +119,10 @@ func ReadProcess(pid int) (model.Process, error) {
 			}
 		case strings.Contains(cgroupStr, "lxc.payload"):
 			name := extractLXCBasedContainerName(cgroupStr)
-			manager := detectLXCManager(pid)
 			if name != "" {
-				container = manager + ": " + name
+				container = "lxc-based: " + name
 			} else {
-				container = manager
+				container = "lxc-based"
 			}
 		}
 	}
@@ -357,49 +356,4 @@ func extractLXCBasedContainerName(cgroup string) string {
 		rest = rest[:slash]
 	}
 	return rest
-}
-
-func detectLXCManager(pid int) string {
-	for pid > 1 {
-		ppid, err := getParentPID(pid)
-		if err != nil {
-			break
-		}
-		name, err := getProcessName(ppid)
-		if err != nil {
-			break
-		}
-		switch name {
-		case "incusd":
-			return "incus"
-		case "lxd":
-			return "lxd"
-		case "lxc-start":
-			return "lxc"
-		}
-		pid = ppid
-	}
-	return "lxc" // fallback
-}
-
-func getParentPID(pid int) (int, error) {
-	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
-	if err != nil {
-		return 0, err
-	}
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.HasPrefix(line, "PPid:") {
-			ppid, err := strconv.Atoi(strings.TrimSpace(line[5:]))
-			return ppid, err
-		}
-	}
-	return 0, fmt.Errorf("PPid not found")
-}
-
-func getProcessName(pid int) (string, error) {
-	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(data)), nil
 }

--- a/internal/proc/process_linux.go
+++ b/internal/proc/process_linux.go
@@ -117,6 +117,12 @@ func ReadProcess(pid int) (model.Process, error) {
 			} else if strings.Contains(cgroupStr, "colima") {
 				container = "colima: default"
 			}
+		case strings.Contains(cgroupStr, "lxc.payload"):
+			if name := extractIncusContainerName(cgroupStr); name != "" {
+				container = "incus: " + name
+			} else {
+				container = "incus"
+			}
 		}
 	}
 
@@ -329,4 +335,19 @@ func extractContainerID(cgroup, dashPrefix, slashPrefix string) string {
 		}
 	}
 	return ""
+}
+
+func extractIncusContainerName(cgroup string) string {
+	if idx := strings.Index(cgroup, "lxc.payload."); idx == -1 {
+		return ""
+	} else {
+		rest := cgroup[idx+len("lxc.payload."):]
+		if u := strings.Index(rest, "_"); u != -1 {
+			rest = rest[u+1:]
+		}
+		if slash := strings.Index(rest, "/"); slash != -1 {
+			rest = rest[:slash]
+		}
+		return rest
+	}
 }

--- a/internal/proc/process_linux.go
+++ b/internal/proc/process_linux.go
@@ -118,10 +118,12 @@ func ReadProcess(pid int) (model.Process, error) {
 				container = "colima: default"
 			}
 		case strings.Contains(cgroupStr, "lxc.payload"):
-			if name := extractIncusContainerName(cgroupStr); name != "" {
-				container = "incus: " + name
+			name := extractLXCBasedContainerName(cgroupStr)
+			manager := detectLXCManager(pid)
+			if name != "" {
+				container = manager + ": " + name
 			} else {
-				container = "incus"
+				container = manager
 			}
 		}
 	}
@@ -337,17 +339,67 @@ func extractContainerID(cgroup, dashPrefix, slashPrefix string) string {
 	return ""
 }
 
-func extractIncusContainerName(cgroup string) string {
-	if idx := strings.Index(cgroup, "lxc.payload."); idx == -1 {
+func extractLXCBasedContainerName(cgroup string) string {
+	idx := strings.Index(cgroup, "lxc.payload.")
+	if idx == -1 {
 		return ""
-	} else {
-		rest := cgroup[idx+len("lxc.payload."):]
+	}
+	rest := cgroup[idx+len("lxc.payload."):]
+
+	// Only strip "user-<uid>_" prefix, not arbitrary underscores
+	if strings.HasPrefix(rest, "user-") {
 		if u := strings.Index(rest, "_"); u != -1 {
 			rest = rest[u+1:]
 		}
-		if slash := strings.Index(rest, "/"); slash != -1 {
-			rest = rest[:slash]
-		}
-		return rest
 	}
+
+	if slash := strings.Index(rest, "/"); slash != -1 {
+		rest = rest[:slash]
+	}
+	return rest
+}
+
+func detectLXCManager(pid int) string {
+	for pid > 1 {
+		ppid, err := getParentPID(pid)
+		if err != nil {
+			break
+		}
+		name, err := getProcessName(ppid)
+		if err != nil {
+			break
+		}
+		switch name {
+		case "incusd":
+			return "incus"
+		case "lxd":
+			return "lxd"
+		case "lxc-start":
+			return "lxc"
+		}
+		pid = ppid
+	}
+	return "lxc" // fallback
+}
+
+func getParentPID(pid int) (int, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
+	if err != nil {
+		return 0, err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "PPid:") {
+			ppid, err := strconv.Atoi(strings.TrimSpace(line[5:]))
+			return ppid, err
+		}
+	}
+	return 0, fmt.Errorf("PPid not found")
+}
+
+func getProcessName(pid int) (string, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
 }

--- a/internal/proc/process_linux_test.go
+++ b/internal/proc/process_linux_test.go
@@ -109,7 +109,7 @@ func TestExtractContainerID(t *testing.T) {
 	}
 }
 
-func TestExtractIncusContainerName(t *testing.T) {
+func TestExtractLXCBasedContainerName(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name   string
@@ -117,17 +117,22 @@ func TestExtractIncusContainerName(t *testing.T) {
 		want   string
 	}{
 		{
-			name:   "user-owned container",
+			name:   "incus user-owned container",
 			cgroup: "0::/lxc.payload.user-1000_alpine-container/.lxc",
 			want:   "alpine-container",
 		},
 		{
-			name:   "root-owned container (no user prefix)",
+			name:   "lxc root-owned container (no user prefix)",
 			cgroup: "0::/lxc.payload.my-container/.lxc",
 			want:   "my-container",
 		},
 		{
-			name:   "not an incus container",
+			name:   "lxc container with underscores in name",
+			cgroup: "0::/lxc.payload.test_raw_lxc_container_underline/.lxc",
+			want:   "test_raw_lxc_container_underline",
+		},
+		{
+			name:   "non-lxc cgroup (docker)",
 			cgroup: "0::/system.slice/docker-abc123.scope",
 			want:   "",
 		},
@@ -141,8 +146,8 @@ func TestExtractIncusContainerName(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := extractIncusContainerName(tt.cgroup); got != tt.want {
-				t.Errorf("extractIncusContainerName(%q) = %q, want %q", tt.cgroup, got, tt.want)
+			if got := extractLXCBasedContainerName(tt.cgroup); got != tt.want {
+				t.Errorf("extractLXCBasedContainerName(%q) = %q, want %q", tt.cgroup, got, tt.want)
 			}
 		})
 	}

--- a/internal/proc/process_linux_test.go
+++ b/internal/proc/process_linux_test.go
@@ -108,3 +108,42 @@ func TestExtractContainerID(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractIncusContainerName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		cgroup string
+		want   string
+	}{
+		{
+			name:   "user-owned container",
+			cgroup: "0::/lxc.payload.user-1000_alpine-container/.lxc",
+			want:   "alpine-container",
+		},
+		{
+			name:   "root-owned container (no user prefix)",
+			cgroup: "0::/lxc.payload.my-container/.lxc",
+			want:   "my-container",
+		},
+		{
+			name:   "not an incus container",
+			cgroup: "0::/system.slice/docker-abc123.scope",
+			want:   "",
+		},
+		{
+			name:   "empty cgroup",
+			cgroup: "",
+			want:   "",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := extractIncusContainerName(tt.cgroup); got != tt.want {
+				t.Errorf("extractIncusContainerName(%q) = %q, want %q", tt.cgroup, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/source/container.go
+++ b/internal/source/container.go
@@ -42,6 +42,11 @@ func detectContainer(ancestry []model.Process) *model.Source {
 				Type: model.SourceContainer,
 				Name: "containerd",
 			}
+		case strings.Contains(content, "lxc.payload"):
+			return &model.Source{
+				Type: model.SourceContainer,
+				Name: detectLXCRuntime(ancestry),
+			}
 		}
 	}
 
@@ -69,4 +74,18 @@ func detectContainer(ancestry []model.Process) *model.Source {
 
 func itoa(n int) string {
 	return strconv.Itoa(n)
+}
+
+func detectLXCRuntime(ancestry []model.Process) string {
+	for _, a := range ancestry {
+		switch a.Command {
+		case "incusd":
+			return "incus"
+		case "lxd":
+			return "lxd"
+		case "lxc-start":
+			return "lxc"
+		}
+	}
+	return "lxc" // fallback
 }


### PR DESCRIPTION
# Description
 
Adds detection of incus/LXC containers via cgroup `lxc.payload` pattern on Linux.
When a PID belongs to an incus container, witr now shows `Container: incus: <container-name>` in the output.
 
Before:
```
Target      : nc
Process     : nc (pid 71426) {forked}
User        : 1000000
Command     : nc -l -p 8080
```
 
After:
```
Target      : nc
Process     : nc (pid 71426) {forked}
User        : 1000000
Container   : incus: alpine-container
Command     : nc -l -p 8080
```
 
Closes #200.
 
## Type of change
 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (may affect existing functionality)
- [ ] This change requires a documentation update
## Checklist
 
- [x] I have formatted my code using `go fmt ./...`
- [x] I have opened this PR against the `staging` branch
- [x] I have performed a self-review of my own code
- [ ] I have added helpful comments where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
For full runtime enrichment (image, network, created time, health — similar to Docker output), we explored using incus list --format json but it returns all containers globally. incus info <name> --format json doesn't support the --format flag, and incus query /1.0/instances/<name> works but feels like reaching into internals.
Happy to implement a full runtime_incus.go if maintainers can suggest the preferred approach for querying per-container metadata.