### PR TITLE
fix(output): use bright ANSI colors for dark-theme contrast

### DIFF
--- a/internal/output/colors.go
+++ b/internal/output/colors.go
@@ -1,12 +1,13 @@
 package output
 
+// Bright ANSI codes (90-97) replace standard (30-37) for contrast on dark themes.
 var (
 	ColorReset     = ansiString("\033[0m")
-	ColorRed       = ansiString("\033[31m")
-	ColorGreen     = ansiString("\033[32m")
-	ColorBlue      = ansiString("\033[34m")
-	ColorCyan      = ansiString("\033[36m")
-	ColorMagenta   = ansiString("\033[35m")
-	ColorDim       = ansiString("\033[2m")
-	ColorDimYellow = ansiString("\033[2;33m")
+	ColorRed       = ansiString("\033[91m")
+	ColorGreen     = ansiString("\033[92m")
+	ColorBlue      = ansiString("\033[94m")
+	ColorCyan      = ansiString("\033[96m")
+	ColorMagenta   = ansiString("\033[95m")
+	ColorDim       = ansiString("\033[90m")
+	ColorDimYellow = ansiString("\033[93m")
 )


### PR DESCRIPTION
## Description
Switches the terminal color constants in `internal/output/colors.go` from standard ANSI codes (30-37) to their bright variants (90-97). Standard colors render too dark on dark terminal themes, making labels like `Target`, `Process`, `User`, and `Command` hard to read. This is a single-file, data-only change — no call sites were touched, since every other file just consumes these constants.

Closes #204
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (may affect existing functionality)
- [ ] This change requires a documentation update

## Checklist
- [x] I have formatted my code using `go fmt ./...`
- [x] I have opened this PR against the `staging` branch
- [x] I have performed a self-review of my own code
- [x] I have added helpful comments where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes


## Screenshots

Tested in both light and dark variants across two terminal themes (GNOME and Tango) to confirm the bright colors hold up on both ends without the light-theme contrast tipping too far the other way.

**Gnome Dark**
<img width="1238" height="516" alt="204-fix-gnome-dark" src="https://github.com/user-attachments/assets/0627876b-7924-4db7-bdbd-82b83026ede7" />

**Gnome Light**
<img width="1238" height="516" alt="204-fix-gnome-light" src="https://github.com/user-attachments/assets/aaf6cb04-9853-4114-8392-c7b25483c964" />

**Tango Dark**
<img width="1238" height="516" alt="204-fix-tango-dark" src="https://github.com/user-attachments/assets/0f152d61-eaaf-4b9c-ad8e-8def8b69c869" />

**Tango Light**
<img width="1238" height="516" alt="204-fix-tango-light" src="https://github.com/user-attachments/assets/3794a1da-cf49-4dd4-ad05-a09f0d46d055" />