### PR TITLE
feat: Add anonymous analytics via GoatCounter

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -79,6 +79,7 @@ docs/
   index.html            page shell
   css/styles.css        terminal-first theme (dark + light)
   js/
+    analytics.js        optional GoatCounter wrapper (no-ops when blocked)
     ansi.js             ANSI escape → HTML
     engine.js           faithful witr output engine  ← fidelity-critical
     parser.js           witr command-line parser
@@ -115,6 +116,17 @@ node docs/scripts/check-fixtures.mjs
 Fixtures embed absolute timestamps and a pinned clock (`_meta.json`), so every
 regeneration changes the timestamps — that's expected. The check uses the pinned
 clock, so it stays deterministic.
+
+## Analytics
+
+The site counts visits and a handful of anonymous events (tutorial started /
+completed, tasks resolved, TUI opened, install command copied) via
+[GoatCounter](https://www.goatcounter.com/) — cookieless, no identifier stored
+in the browser, and the dashboard is public:
+<https://witr.goatcounter.com>. `js/analytics.js` is a thin wrapper that
+silently no-ops when the counter script is blocked or unavailable, so the
+playground never depends on it. A note in the page footer discloses this to
+visitors.
 
 ## Adding a scenario
 

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -368,6 +368,8 @@ a.brand-mark:hover { text-decoration: underline; }
 
 /* chips (mobile suggested commands) */
 .chips { display: none; gap: 8px; padding: 10px 12px; border-top: 1px solid var(--line); background: var(--panel); overflow-x: auto; flex: 0 0 auto; }
+.stats-note { flex: 0 0 auto; padding: 4px 12px 6px; border-top: 1px solid var(--line); background: var(--panel); font-size: 10.5px; color: var(--text-faint); text-align: right; }
+.stats-note a { color: var(--text-dim); text-decoration: underline dotted; }
 .chip {
   flex: 0 0 auto; font-family: var(--mono); font-size: 12px; white-space: nowrap;
   border: 1px solid var(--line-2); background: var(--panel-2); color: var(--accent-2);

--- a/docs/index.html
+++ b/docs/index.html
@@ -47,6 +47,7 @@
       </div>
       <div id="terminal" tabindex="0"></div>
       <div id="chips" class="chips"></div>
+      <div class="stats-note">anonymous, cookieless <a href="https://witr.goatcounter.com" target="_blank" rel="noopener">visit stats</a> — nothing is stored in your browser</div>
     </div>
 
     <div class="right-col">
@@ -138,6 +139,8 @@
   <div id="tui" class="tui" aria-hidden="true"></div>
 
   <script type="module" src="js/app.js"></script>
+  <script data-goatcounter="https://witr.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
   <script>
     // Close-scenario button (non-module handler for simplicity).
     document.querySelector('[data-close-scenario]')?.addEventListener('click', () => {

--- a/docs/js/analytics.js
+++ b/docs/js/analytics.js
@@ -1,0 +1,44 @@
+// analytics.js — thin, optional wrapper around GoatCounter (goatcounter.com).
+//
+// The playground must never depend on analytics: when the counter script is
+// blocked (adblockers), offline, or absent, every call here is a silent no-op.
+// Counts are anonymous and cookieless — nothing is stored in the visitor's
+// browser — and the dashboard is public: https://witr.goatcounter.com
+//
+// count.js loads async, so events fired before it arrives (e.g. the tutorial
+// starting on page load) are queued and flushed once it's ready; if it never
+// arrives the queue is quietly abandoned. Each event is counted at most once
+// per page load: the interesting numbers are per-visit ratios (started vs
+// completed), not repeat clicks.
+
+const seen = new Set();
+const queue = [];
+let retryTimer = null;
+
+function flush() {
+  const gc = window.goatcounter;
+  if (!gc || typeof gc.count !== 'function') return false;
+  while (queue.length) {
+    const path = queue.shift();
+    try {
+      gc.count({ path, event: true });
+    } catch (_) {
+      // Analytics must never surface an error to the playground.
+    }
+  }
+  return true;
+}
+
+export function track(name) {
+  if (seen.has(name)) return;
+  seen.add(name);
+  queue.push(name);
+  if (flush() || retryTimer) return;
+  let tries = 0;
+  retryTimer = setInterval(() => {
+    if (flush() || ++tries >= 15) {
+      clearInterval(retryTimer);
+      retryTimer = null;
+    }
+  }, 1000);
+}

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -7,6 +7,7 @@ import { Tree } from './tree.js';
 import { Incident, INCIDENTS } from './tutorial.js';
 import { TUI } from './tui.js';
 import { parse, tokenize } from './parser.js';
+import { track } from './analytics.js';
 
 const VERSION_URL = 'https://raw.githubusercontent.com/pranshuparmar/witr/main/internal/version/VERSION';
 
@@ -49,9 +50,9 @@ class App {
     this.tui.onKill = (pid) => this.killFromTui(pid);
 
     this.incident.onChange = () => this.renderIncident();
-    this.incident.onResolve = (issue) => this.onIssueResolved(issue);
-    this.incident.onComplete = () => this.onIncidentComplete();
-    this.incident.onQuestTried = (q) => this.onQuestTried(q);
+    this.incident.onResolve = (issue) => { track(`task-resolved-${issue.id}`); this.onIssueResolved(issue); };
+    this.incident.onComplete = () => { track(`tutorial-completed-${this.worldId}`); this.onIncidentComplete(); };
+    this.incident.onQuestTried = (q) => { track(`quest-tried-${q.id}`); this.onQuestTried(q); };
 
     this.viewSetWorld(this.live);
     this.map.start();
@@ -144,6 +145,7 @@ class App {
   enterScenario() {
     const def = INCIDENTS[this.worldId];
     if (def) {
+      track(`tutorial-started-${this.worldId}`);
       this.incident.load(def);
       this.incident.start();      // phase = coldopen
       this.playColdOpen(def);
@@ -443,6 +445,7 @@ class App {
   // incident, wipe the screen so the story doesn't linger, and drop a short
   // welcome so free play never starts on a blank void.
   exitToFreePlay() {
+    track('free-play-entered');
     if (this._autoTimers) { for (const id of Object.keys(this._autoTimers)) clearTimeout(this._autoTimers[id]); this._autoTimers = {}; }
     this.incident.stop();
     this.term.clear();
@@ -547,7 +550,9 @@ class App {
 
     // Install popup.
     const install = document.getElementById('install-modal');
-    document.getElementById('btn-install').addEventListener('click', () => install.classList.add('open'));
+    document.getElementById('btn-install').addEventListener('click', () => { track('install-modal-opened'); install.classList.add('open'); });
+    document.querySelectorAll('a.brand-mark, a.btn-star').forEach((a) =>
+      a.addEventListener('click', () => track(a.classList.contains('btn-star') ? 'outbound-star' : 'outbound-repo')));
     install.addEventListener('click', (e) => { if (e.target === install) install.classList.remove('open'); });
     document.querySelector('[data-close-install]').addEventListener('click', () => install.classList.remove('open'));
     install.querySelectorAll('[data-copy]').forEach((b) =>
@@ -561,6 +566,7 @@ class App {
 
   // Copy text to the clipboard and flash a brief confirmation on the button.
   copyToClipboard(text, btn) {
+    track('install-copied');
     const done = () => {
       if (!btn) return;
       btn.classList.add('copied');
@@ -617,6 +623,7 @@ class App {
   }
 
   openTui() {
+    track('tui-opened');
     this.tui.show(this.currentWorld(), this.shell.engine, this.shell.version);
     this.incident.observe({ targets: [], flags: {}, action: 'tui', world: this.currentWorld() });
     if (this.incident.phase === 'done') this.refreshQuests();
@@ -665,6 +672,7 @@ class App {
 
   switchWorld(id) {
     if (!this.pristine[id]) return;
+    track(`scenario-switched-${id}`);
     this.worldId = id;
     document.getElementById('scenario-modal').classList.remove('open');
     this.resetScenario();


### PR DESCRIPTION
## Description

This PR adds optional, privacy-respecting analytics to the playground using GoatCounter. The implementation tracks key user interactions (tutorial started/completed, tasks resolved, TUI opened, install command copied, scenario switches, and outbound clicks) while maintaining the principle that the playground never depends on analytics.

The `analytics.js` module is a thin wrapper that silently no-ops when the GoatCounter script is blocked by adblockers, offline, or unavailable. Events are deduplicated per page load and queued until the counter script loads, with automatic retry logic. The dashboard is public at https://witr.goatcounter.com.

A footer note discloses the analytics to visitors, emphasizing that nothing is stored in their browser.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Changes

- **docs/js/analytics.js** (new): Thin wrapper around GoatCounter with queue/retry logic and deduplication
- **docs/js/app.js**: Integrated `track()` calls at 8 key user interaction points
- **docs/index.html**: Added GoatCounter script tag and footer disclosure note
- **docs/css/styles.css**: Styled the stats disclosure footer
- **docs/README.md**: Documented the analytics implementation and privacy approach

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added helpful comments where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Test Plan

The analytics module is defensive by design—all calls are silent no-ops if GoatCounter is unavailable. Manual verification:
1. Open the playground and verify the footer disclosure appears
2. Open DevTools and confirm no errors occur (analytics failures are caught)
3. Verify key interactions trigger tracking (tutorial start, task completion, TUI open, etc.)
4. Test with adblocker enabled to confirm the playground functions normally
5. Check the public dashboard at https://witr.goatcounter.com to see aggregated stats

https://claude.ai/code/session_01K4HgTJBEvAQBjstvdUcrYQ