### PR TITLE
feat(tui): add Network tab with host and Docker topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,18 +529,19 @@ Remove-Item -Recurse -Force "$env:LocalAppData\witr"
  
 ## 3. Interactive Mode (TUI)
 
-Running `witr` without any arguments or with the `-i` flag launches the **Interactive Mode (TUI)**. This provides a real-time, terminal-based dashboard with four tabs for exploring processes, ports, containers, and file locks.
+Running `witr` without any arguments or with the `-i` flag launches the **Interactive Mode (TUI)**. This provides a real-time, terminal-based dashboard with tabs for exploring processes, ports, containers, file locks, and Docker/host networking.
 
 ### Key Features:
 - **Processes Tab**: Live, sortable, filterable list of all running processes with a side panel showing the ancestry tree of the highlighted process.
 - **Ports Tab**: Open/listening ports with the owning processes attached in a side panel. Toggle between LISTEN-only and ALL with `a`.
 - **Containers Tab**: All running containers across Docker, Podman, nerdctl, K8s/crictl, Incus, LXC, LXD, and FreeBSD jails in one list - name, image, status, ports, command, plus a per-container detail view with mounts, networks, and compose project metadata.
 - **Locks Tab**: System-wide file locks (POSIX/FLOCK on Linux, lsof-derived on macOS/FreeBSD). Press `a` to switch into "all open files" mode, where locked entries are merged with every interesting open fd; type into `/` to search across the merged set.
+- **Network Tab**: Combined host machine adapters and Docker networks in one table (`Source` = Host or Docker). Host data comes from OS tools (`ipconfig /all` on Windows, `ip addr` on Linux, portable fallback elsewhere). Press `a` to filter ALL / HOST / DOCKER. Side panel shows interface details or Docker network metadata and endpoints.
 - **Process Details**: Deep-dive into a process to see its full ancestry tree, child processes, environment variables, working directory, sockets, file context, and more.
 - **Process Actions**: Send signals (Kill, Terminate, Pause, Resume) or Renice processes directly from the UI (Unix only).
 - **Mouse Support**: Navigate, sort columns, and click rows using your mouse.
 - **Adaptive Theme**: Colors adapt automatically to light and dark terminal backgrounds.
-- **Auto-Refresh**: The process, port, container, and lock lists refresh automatically on an adaptive cadence (starts at 3 seconds, backing off under load).
+- **Auto-Refresh**: The process, port, container, lock, and network lists refresh automatically on an adaptive cadence (starts at 3 seconds, backing off under load).
 
 ---
 

--- a/internal/proc/docker_binary_other.go
+++ b/internal/proc/docker_binary_other.go
@@ -1,0 +1,6 @@
+//go:build !windows
+
+package proc
+
+// dockerBinaryCandidates is a no-op off Windows; PATH is the usual source.
+func dockerBinaryCandidates() string { return "" }

--- a/internal/proc/docker_binary_windows.go
+++ b/internal/proc/docker_binary_windows.go
@@ -1,0 +1,47 @@
+//go:build windows
+
+package proc
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// dockerBinaryCandidates returns a full path to docker.exe when it is installed
+// in a common Docker Desktop location but missing from PATH.
+func dockerBinaryCandidates() string {
+	var roots []string
+	if pf := os.Getenv("ProgramFiles"); pf != "" {
+		roots = append(roots, pf)
+	}
+	if pf86 := os.Getenv("ProgramFiles(x86)"); pf86 != "" {
+		roots = append(roots, pf86)
+	}
+	roots = append(roots,
+		`C:\Program Files`,
+		`C:\Program Files (x86)`,
+	)
+	// LocalAppData\Docker\wsl and user installs are less common for the CLI.
+	if la := os.Getenv("LOCALAPPDATA"); la != "" {
+		roots = append(roots, la)
+	}
+
+	rel := []string{
+		filepath.Join("Docker", "Docker", "resources", "bin", "docker.exe"),
+		filepath.Join("Docker", "Docker", "resources", "docker.exe"),
+	}
+	seen := make(map[string]struct{})
+	for _, root := range roots {
+		for _, r := range rel {
+			p := filepath.Join(root, r)
+			if _, dup := seen[p]; dup {
+				continue
+			}
+			seen[p] = struct{}{}
+			if st, err := os.Stat(p); err == nil && !st.IsDir() {
+				return p
+			}
+		}
+	}
+	return ""
+}

--- a/internal/proc/docker_network.go
+++ b/internal/proc/docker_network.go
@@ -1,0 +1,240 @@
+package proc
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/pranshuparmar/witr/pkg/model"
+)
+
+// ListNetworkSnapshot gathers Docker networks, host interfaces, and (when
+// available) veth→bridge mapping for the TUI Network tab. Best-effort: missing
+// docker or elevated rights never returns an error to the caller.
+func ListNetworkSnapshot() model.NetworkSnapshot {
+	snap := model.NetworkSnapshot{
+		VethByBridge: make(map[string][]string),
+	}
+
+	// OS-specific host adapters: ipconfig (Windows), ip addr (Linux), net fallback.
+	snap.HostIfaces, snap.HostSource = listHostInterfacesWithSource()
+	vethMap := listVethMap()
+	for name, info := range vethMap {
+		b := info.Bridge
+		if b == "" {
+			b = "unconnected"
+		}
+		snap.VethByBridge[b] = append(snap.VethByBridge[b], name)
+	}
+	for b := range snap.VethByBridge {
+		sort.Strings(snap.VethByBridge[b])
+	}
+
+	dockerBin := resolveDockerBinary()
+	if dockerBin == "" {
+		snap.Error = "Docker not available (install Docker or add docker to PATH)"
+		return snap
+	}
+
+	networks, contStatus, ok := collectDockerNetworks(dockerBin)
+	snap.DockerOK = ok
+	snap.Networks = networks
+	if !ok && snap.Error == "" {
+		snap.Error = "Failed to query Docker networks (is the engine running?)"
+	}
+
+	// Attach short status text from docker ps -a onto endpoints.
+	for i := range snap.Networks {
+		for j := range snap.Networks[i].Containers {
+			cname := snap.Networks[i].Containers[j].Name
+			if st, found := contStatus[cname]; found {
+				snap.Networks[i].Containers[j].Status = st
+			}
+		}
+	}
+
+	return snap
+}
+
+// resolveDockerBinary returns a docker CLI path. LookPath first, then common
+// Docker Desktop install locations (Windows terminals often lack the PATH entry).
+func resolveDockerBinary() string {
+	if binAvailable("docker") {
+		return "docker"
+	}
+	return dockerBinaryCandidates()
+}
+
+type vethInfo struct {
+	PeerIf  string
+	Bridge  string
+	NetnsID string
+}
+
+func collectDockerNetworks(dockerBin string) ([]model.DockerNetwork, map[string]string, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	lsOut, err := exec.CommandContext(ctx, dockerBin, "network", "ls",
+		"--format", "{{.Name}}|{{.ID}}|{{.Driver}}|{{.Scope}}").Output()
+	if err != nil {
+		return nil, nil, false
+	}
+
+	contStatus := dockerContainerStatusMap(ctx, dockerBin)
+
+	var networks []model.DockerNetwork
+	for _, line := range strings.Split(strings.TrimSpace(string(lsOut)), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.Split(line, "|")
+		if len(parts) < 4 {
+			continue
+		}
+		name := parts[0]
+		netID := parts[1]
+		if len(netID) > 12 {
+			netID = netID[:12]
+		}
+		dn := model.DockerNetwork{
+			Name:   name,
+			ID:     netID,
+			Driver: parts[2],
+			Scope:  parts[3],
+		}
+		enrichDockerNetwork(ctx, dockerBin, &dn)
+		networks = append(networks, dn)
+	}
+
+	sort.Slice(networks, func(i, j int) bool {
+		return networks[i].Name < networks[j].Name
+	})
+	return networks, contStatus, true
+}
+
+func dockerContainerStatusMap(ctx context.Context, dockerBin string) map[string]string {
+	out := make(map[string]string)
+	raw, err := exec.CommandContext(ctx, dockerBin, "ps", "-a",
+		"--format", "{{.Names}}|{{.Status}}").Output()
+	if err != nil {
+		return out
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "|", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		st := parts[1]
+		// Compact status for table cells.
+		switch {
+		case strings.HasPrefix(st, "Up"):
+			out[parts[0]] = "Up"
+		case strings.HasPrefix(st, "Exited"):
+			out[parts[0]] = "Exited"
+		case strings.HasPrefix(st, "Created"):
+			out[parts[0]] = "Created"
+		default:
+			if len(st) > 16 {
+				st = st[:16]
+			}
+			out[parts[0]] = st
+		}
+	}
+	return out
+}
+
+func enrichDockerNetwork(ctx context.Context, dockerBin string, dn *model.DockerNetwork) {
+	raw, err := exec.CommandContext(ctx, dockerBin, "network", "inspect", dn.Name).Output()
+	if err != nil {
+		return
+	}
+
+	var data []map[string]interface{}
+	if err := json.Unmarshal(raw, &data); err != nil || len(data) == 0 {
+		return
+	}
+	netData := data[0]
+	parseDockerNetworkInspect(dn, netData)
+}
+
+// parseDockerNetworkInspect fills dn from one docker network inspect object.
+// Exported for tests via the unexported name still package-visible.
+func parseDockerNetworkInspect(dn *model.DockerNetwork, netData map[string]interface{}) {
+	if opts, ok := netData["Options"].(map[string]interface{}); ok {
+		if bname, ok := opts["com.docker.network.bridge.name"].(string); ok {
+			dn.BridgeInterface = bname
+		}
+	}
+	if dn.BridgeInterface == "" {
+		switch dn.Name {
+		case "bridge":
+			dn.BridgeInterface = "docker0"
+		case "host", "none":
+			dn.BridgeInterface = dn.Name
+		default:
+			dn.BridgeInterface = "br-" + dn.ID
+		}
+	}
+
+	if ipam, ok := netData["IPAM"].(map[string]interface{}); ok {
+		if cfg, ok := ipam["Config"].([]interface{}); ok && len(cfg) > 0 {
+			if c0, ok := cfg[0].(map[string]interface{}); ok {
+				if s, ok := c0["Subnet"].(string); ok {
+					dn.Subnet = s
+				}
+				if g, ok := c0["Gateway"].(string); ok {
+					dn.Gateway = g
+				}
+			}
+		}
+	}
+	if dn.Subnet == "" {
+		dn.Subnet = "N/A"
+	}
+	if dn.Gateway == "" {
+		dn.Gateway = "N/A"
+	}
+
+	if conts, ok := netData["Containers"].(map[string]interface{}); ok {
+		for cid, cinfoRaw := range conts {
+			cinfo, ok := cinfoRaw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			cname, _ := cinfo["Name"].(string)
+			if cname == "" {
+				cname = cid
+				if len(cname) > 12 {
+					cname = cname[:12]
+				}
+			}
+			ip, _ := cinfo["IPv4Address"].(string)
+			mac, _ := cinfo["MacAddress"].(string)
+			epid, _ := cinfo["EndpointID"].(string)
+			if len(epid) > 12 {
+				epid = epid[:12]
+			}
+			shortID := cid
+			if len(shortID) > 12 {
+				shortID = shortID[:12]
+			}
+			dn.Containers = append(dn.Containers, model.DockerNetworkEndpoint{
+				Name:       cname,
+				ID:         shortID,
+				IP:         ip,
+				MAC:        mac,
+				EndpointID: epid,
+			})
+		}
+		sort.Slice(dn.Containers, func(i, j int) bool {
+			return dn.Containers[i].Name < dn.Containers[j].Name
+		})
+	}
+}

--- a/internal/proc/docker_network_test.go
+++ b/internal/proc/docker_network_test.go
@@ -1,0 +1,92 @@
+package proc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/pranshuparmar/witr/pkg/model"
+)
+
+func TestParseDockerNetworkInspect(t *testing.T) {
+	const raw = `[
+  {
+    "Name": "bridge",
+    "Id": "abc123def456789",
+    "Driver": "bridge",
+    "Scope": "local",
+    "Options": {
+      "com.docker.network.bridge.name": "docker0"
+    },
+    "IPAM": {
+      "Config": [
+        {
+          "Subnet": "172.17.0.0/16",
+          "Gateway": "172.17.0.1"
+        }
+      ]
+    },
+    "Containers": {
+      "0123456789abcdef0123456789abcdef": {
+        "Name": "web",
+        "IPv4Address": "172.17.0.2/16",
+        "MacAddress": "02:42:ac:11:00:02",
+        "EndpointID": "endpoint1234567890"
+      }
+    }
+  }
+]`
+	var data []map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &data); err != nil {
+		t.Fatal(err)
+	}
+	dn := model.DockerNetwork{Name: "bridge", ID: "abc123def456"}
+	parseDockerNetworkInspect(&dn, data[0])
+
+	if dn.BridgeInterface != "docker0" {
+		t.Errorf("BridgeInterface = %q, want docker0", dn.BridgeInterface)
+	}
+	if dn.Subnet != "172.17.0.0/16" {
+		t.Errorf("Subnet = %q", dn.Subnet)
+	}
+	if dn.Gateway != "172.17.0.1" {
+		t.Errorf("Gateway = %q", dn.Gateway)
+	}
+	if len(dn.Containers) != 1 {
+		t.Fatalf("Containers len = %d", len(dn.Containers))
+	}
+	c := dn.Containers[0]
+	if c.Name != "web" || c.IP != "172.17.0.2/16" {
+		t.Errorf("endpoint = %+v", c)
+	}
+}
+
+func TestDetectInterfaceType(t *testing.T) {
+	cases := map[string]string{
+		"eth0":    "physical",
+		"enp0s3":  "physical",
+		"wlan0":   "wireless",
+		"docker0": "bridge",
+		"br-abc":  "bridge",
+		"veth123": "veth",
+		"lo":      "loopback",
+		"wg0":     "wireguard",
+		"tun0":    "tun/tap",
+	}
+	for name, want := range cases {
+		if got := detectInterfaceType(name); got != want {
+			t.Errorf("detectInterfaceType(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestListNetworkSnapshotNoPanic(t *testing.T) {
+	// Must not panic whether or not Docker is installed.
+	snap := ListNetworkSnapshot()
+	if snap.VethByBridge == nil {
+		t.Error("VethByBridge should be non-nil map")
+	}
+	// Host ifaces should usually be non-empty on a real machine.
+	if snap.HostIfaces == nil {
+		t.Error("HostIfaces should not be nil")
+	}
+}

--- a/internal/proc/host_ifaces_common.go
+++ b/internal/proc/host_ifaces_common.go
@@ -1,0 +1,57 @@
+package proc
+
+import (
+	"net"
+	"sort"
+
+	"github.com/pranshuparmar/witr/pkg/model"
+)
+
+// listHostInterfacesStdlib is the portable fallback using Go's net package.
+func listHostInterfacesStdlib() []model.HostInterface {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil
+	}
+	var result []model.HostInterface
+	for _, iface := range ifaces {
+		state := "DOWN"
+		if iface.Flags&net.FlagUp != 0 {
+			state = "UP"
+		}
+		var ipv4, ipv6 []string
+		addrs, _ := iface.Addrs()
+		for _, a := range addrs {
+			s := a.String()
+			if ipnet, ok := a.(*net.IPNet); ok {
+				if ip4 := ipnet.IP.To4(); ip4 != nil {
+					ipv4 = append(ipv4, s)
+				} else if ipnet.IP.To16() != nil && !ipnet.IP.IsLinkLocalUnicast() {
+					ipv6 = append(ipv6, s)
+				}
+			} else {
+				ipv4 = append(ipv4, s)
+			}
+		}
+		mac := iface.HardwareAddr.String()
+		if mac == "" {
+			mac = "N/A"
+		}
+		mtu := iface.MTU
+		if mtu < 0 {
+			mtu = 0 // Windows loopback reports MTU=-1; treat as unknown.
+		}
+		result = append(result, model.HostInterface{
+			Name:    iface.Name,
+			Type:    detectInterfaceType(iface.Name),
+			State:   state,
+			MTU:     mtu,
+			MAC:     mac,
+			IPv4:    ipv4,
+			IPv6:    ipv6,
+			IfIndex: iface.Index,
+		})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+	return result
+}

--- a/internal/proc/host_ifaces_linux.go
+++ b/internal/proc/host_ifaces_linux.go
@@ -1,0 +1,223 @@
+//go:build linux
+
+package proc
+
+import (
+	"encoding/json"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/pranshuparmar/witr/pkg/model"
+)
+
+type ipAddrJSON []struct {
+	IfIndex   int    `json:"ifindex"`
+	IfName    string `json:"ifname"`
+	OperState string `json:"operstate"`
+	MTU       int    `json:"mtu"`
+	Address   string `json:"address"`
+	AddrInfo  []struct {
+		Family    string `json:"family"`
+		Local     string `json:"local"`
+		PrefixLen int    `json:"prefixlen"`
+		Scope     string `json:"scope"`
+	} `json:"addr_info"`
+}
+
+func listHostInterfaces() []model.HostInterface {
+	ifaces, _ := listHostInterfacesWithSource()
+	return ifaces
+}
+
+func listHostInterfacesWithSource() ([]model.HostInterface, string) {
+	// Prefer structured `ip -j addr show`, then plain `ip addr show`, then stdlib.
+	out, err := exec.Command("ip", "-j", "addr", "show").Output()
+	if err == nil && len(out) > 0 {
+		var data ipAddrJSON
+		if err := json.Unmarshal(out, &data); err == nil && len(data) > 0 {
+			return hostIfacesFromIPJSON(data), "ip -j addr show"
+		}
+	}
+	if text := fallbackHostInterfaces(); len(text) > 0 {
+		return text, "ip addr show"
+	}
+	return listHostInterfacesStdlib(), "net"
+}
+
+func hostIfacesFromIPJSON(data ipAddrJSON) []model.HostInterface {
+	var ifaces []model.HostInterface
+	for _, iface := range data {
+		name := iface.IfName
+		if name == "" {
+			continue
+		}
+		state := strings.ToUpper(iface.OperState)
+		if state == "" {
+			state = "UNKNOWN"
+		}
+		var ipv4, ipv6 []string
+		for _, a := range iface.AddrInfo {
+			if a.Family == "inet" && a.Local != "" {
+				ipv4 = append(ipv4, fmtPrefix(a.Local, a.PrefixLen))
+			}
+			if a.Family == "inet6" && a.Local != "" && !strings.HasPrefix(a.Local, "fe80") {
+				ipv6 = append(ipv6, fmtPrefix(a.Local, a.PrefixLen))
+			}
+		}
+		ifaces = append(ifaces, model.HostInterface{
+			Name:    name,
+			Type:    detectInterfaceType(name),
+			State:   state,
+			MTU:     iface.MTU,
+			MAC:     iface.Address,
+			IPv4:    ipv4,
+			IPv6:    ipv6,
+			IfIndex: iface.IfIndex,
+		})
+	}
+	sort.Slice(ifaces, func(i, j int) bool { return ifaces[i].Name < ifaces[j].Name })
+	return ifaces
+}
+
+func fmtPrefix(local string, prefix int) string {
+	if prefix > 0 {
+		return local + "/" + itoa(prefix)
+	}
+	return local
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [12]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}
+
+func fallbackHostInterfaces() []model.HostInterface {
+	out, err := exec.Command("ip", "addr", "show").Output()
+	if err != nil {
+		return listHostInterfacesStdlib()
+	}
+	return parseIPAddrText(string(out))
+}
+
+func parseIPAddrText(out string) []model.HostInterface {
+	ifaces := make(map[string]model.HostInterface)
+	var order []string
+	var current string
+
+	reIface := regexp.MustCompile(`^(\d+):\s+(\S+):`)
+	reMAC := regexp.MustCompile(`link/ether\s+(\S+)`)
+	reIPv4 := regexp.MustCompile(`inet\s+(\S+)`)
+	reIPv6 := regexp.MustCompile(`inet6\s+(\S+)\s+scope\s+global`)
+
+	for _, line := range strings.Split(out, "\n") {
+		if m := reIface.FindStringSubmatch(line); m != nil {
+			current = strings.Split(m[2], "@")[0]
+			state := "UNKNOWN"
+			if strings.Contains(line, "UP") {
+				state = "UP"
+			} else if strings.Contains(line, "DOWN") {
+				state = "DOWN"
+			}
+			ifaces[current] = model.HostInterface{
+				Name:  current,
+				Type:  detectInterfaceType(current),
+				State: state,
+				MAC:   "N/A",
+			}
+			order = append(order, current)
+			continue
+		}
+		if current == "" {
+			continue
+		}
+		ifi := ifaces[current]
+		if m := reMAC.FindStringSubmatch(line); m != nil {
+			ifi.MAC = m[1]
+		}
+		if m := reIPv4.FindStringSubmatch(line); m != nil {
+			ifi.IPv4 = append(ifi.IPv4, m[1])
+		}
+		if m := reIPv6.FindStringSubmatch(line); m != nil {
+			ifi.IPv6 = append(ifi.IPv6, m[1])
+		}
+		ifaces[current] = ifi
+	}
+
+	result := make([]model.HostInterface, 0, len(order))
+	for _, n := range order {
+		result = append(result, ifaces[n])
+	}
+	return result
+}
+
+func listVethMap() map[string]vethInfo {
+	vethMap := make(map[string]vethInfo)
+	out, err := exec.Command("ip", "link", "show").Output()
+	if err != nil {
+		return vethMap
+	}
+
+	reVeth := regexp.MustCompile(`^(\d+):\s+(veth[^:@]+)@if(\d+):`)
+	reMaster := regexp.MustCompile(`master\s+(\S+)`)
+	reNetns := regexp.MustCompile(`link-netnsid\s+(\d+)`)
+
+	var current string
+	for _, line := range strings.Split(string(out), "\n") {
+		if m := reVeth.FindStringSubmatch(line); m != nil {
+			current = m[2]
+			vethMap[current] = vethInfo{PeerIf: m[3]}
+			continue
+		}
+		if current == "" {
+			continue
+		}
+		vi := vethMap[current]
+		if m := reMaster.FindStringSubmatch(line); m != nil {
+			vi.Bridge = m[1]
+		}
+		if m := reNetns.FindStringSubmatch(line); m != nil {
+			vi.NetnsID = m[1]
+			vethMap[current] = vi
+			current = ""
+			continue
+		}
+		vethMap[current] = vi
+	}
+	return vethMap
+}
+
+func detectInterfaceType(name string) string {
+	switch {
+	case strings.HasPrefix(name, "eth") || strings.HasPrefix(name, "en"):
+		return "physical"
+	case strings.HasPrefix(name, "wl"):
+		return "wireless"
+	case strings.HasPrefix(name, "br-") || name == "docker0" || strings.HasPrefix(name, "br"):
+		return "bridge"
+	case strings.HasPrefix(name, "veth"):
+		return "veth"
+	case strings.HasPrefix(name, "wg"):
+		return "wireguard"
+	case strings.HasPrefix(name, "tun") || strings.HasPrefix(name, "tap"):
+		return "tun/tap"
+	case name == "lo":
+		return "loopback"
+	case strings.HasPrefix(name, "virbr") || strings.HasPrefix(name, "vnet"):
+		return "libvirt"
+	case strings.Contains(strings.ToLower(name), "docker"):
+		return "docker"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/proc/host_ifaces_other.go
+++ b/internal/proc/host_ifaces_other.go
@@ -1,0 +1,43 @@
+//go:build !linux && !windows
+
+package proc
+
+import (
+	"strings"
+
+	"github.com/pranshuparmar/witr/pkg/model"
+)
+
+func listHostInterfaces() []model.HostInterface {
+	return listHostInterfacesStdlib()
+}
+
+func listHostInterfacesWithSource() ([]model.HostInterface, string) {
+	return listHostInterfacesStdlib(), "net"
+}
+
+func listVethMap() map[string]vethInfo {
+	return map[string]vethInfo{}
+}
+
+func detectInterfaceType(name string) string {
+	lower := strings.ToLower(name)
+	switch {
+	case lower == "lo" || strings.Contains(lower, "loopback") || strings.HasPrefix(lower, "lo"):
+		return "loopback"
+	case strings.HasPrefix(lower, "eth") || strings.HasPrefix(lower, "en") || strings.Contains(lower, "ethernet"):
+		return "physical"
+	case strings.HasPrefix(lower, "wl") || strings.Contains(lower, "wi-fi") || strings.Contains(lower, "wlan"):
+		return "wireless"
+	case strings.HasPrefix(lower, "veth"):
+		return "veth"
+	case strings.Contains(lower, "docker") || strings.HasPrefix(lower, "br-"):
+		return "bridge"
+	case strings.HasPrefix(lower, "wg"):
+		return "wireguard"
+	case strings.HasPrefix(lower, "tun") || strings.HasPrefix(lower, "tap"):
+		return "tun/tap"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/proc/host_ifaces_windows.go
+++ b/internal/proc/host_ifaces_windows.go
@@ -1,0 +1,378 @@
+//go:build windows
+
+package proc
+
+import (
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/pranshuparmar/witr/pkg/model"
+)
+
+// listHostInterfaces prefers `ipconfig /all` (what users expect on Windows),
+// then falls back to the Go net package.
+func listHostInterfaces() []model.HostInterface {
+	if ifaces, src := listHostInterfacesIPConfig(); len(ifaces) > 0 {
+		_ = src
+		return ifaces
+	}
+	return listHostInterfacesStdlib()
+}
+
+func listHostInterfacesWithSource() ([]model.HostInterface, string) {
+	if ifaces, src := listHostInterfacesIPConfig(); len(ifaces) > 0 {
+		return ifaces, src
+	}
+	return listHostInterfacesStdlib(), "net"
+}
+
+func listVethMap() map[string]vethInfo {
+	return map[string]vethInfo{}
+}
+
+func listHostInterfacesIPConfig() ([]model.HostInterface, string) {
+	out, err := exec.Command("ipconfig", "/all").Output()
+	if err != nil || len(out) == 0 {
+		// Some locales ship ipconfig; try without /all.
+		out, err = exec.Command("ipconfig").Output()
+		if err != nil || len(out) == 0 {
+			return nil, ""
+		}
+		return parseIPConfig(string(out)), "ipconfig"
+	}
+	return parseIPConfig(string(out)), "ipconfig /all"
+}
+
+// adapterHeader matches lines like:
+//
+//	Ethernet adapter Ethernet:
+//	Wireless LAN adapter Wi-Fi:
+//	Unknown adapter Local Area Connection* 9:
+var (
+	reAdapterHeader = regexp.MustCompile(`(?i)^(.+?)\s+adapter\s+(.+):\s*$`)
+	reIPConfigKV    = regexp.MustCompile(`(?i)^\s*([^.:]+?)(?:\s*\.\s*)+\s*:\s*(.*)$`)
+	reIPv4Pref      = regexp.MustCompile(`(?i)^(\d+\.\d+\.\d+\.\d+)`)
+	reIPv6Pref      = regexp.MustCompile(`(?i)^([0-9a-f:]+)`)
+)
+
+// parseIPConfig turns ipconfig [/all] text into HostInterface rows.
+func parseIPConfig(text string) []model.HostInterface {
+	// ipconfig may be UTF-16 on some systems; strip BOM and normalize.
+	text = strings.TrimPrefix(text, "\ufeff")
+	// If we got UTF-16 LE misread as a string, newlines may be sparse — still try.
+
+	var (
+		result  []model.HostInterface
+		cur     *model.HostInterface
+		pending string // last key for multi-line values (DNS, etc.)
+	)
+
+	flush := func() {
+		if cur == nil {
+			return
+		}
+		if cur.State == "" {
+			// Media disconnected is often the only signal.
+			if len(cur.IPv4) == 0 && len(cur.IPv6) == 0 {
+				cur.State = "DOWN"
+			} else {
+				cur.State = "UP"
+			}
+		}
+		if cur.Type == "" {
+			cur.Type = detectInterfaceType(cur.Name)
+		}
+		if cur.MAC == "" {
+			cur.MAC = "N/A"
+		}
+		result = append(result, *cur)
+		cur = nil
+		pending = ""
+	}
+
+	for _, raw := range strings.Split(text, "\n") {
+		line := strings.TrimRight(raw, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		if m := reAdapterHeader.FindStringSubmatch(line); m != nil {
+			flush()
+			kind := strings.TrimSpace(m[1])
+			name := strings.TrimSpace(m[2])
+			cur = &model.HostInterface{
+				Name: name,
+				Type: classifyWindowsAdapter(kind, name),
+			}
+			pending = ""
+			continue
+		}
+
+		// Skip the global "Windows IP Configuration" preamble.
+		if cur == nil {
+			continue
+		}
+
+		// Prefer key/value lines (most adapter properties are indented AND
+		// contain "Key . . . : value"). Only treat a line as a multi-value
+		// continuation (extra DNS server, etc.) when it is indented and does
+		// NOT look like a property row.
+		if kv := reIPConfigKV.FindStringSubmatch(line); kv != nil {
+			key := normalizeIPConfigKey(kv[1])
+			val := strings.TrimSpace(kv[2])
+			pending = key
+			applyIPConfigValue(cur, key, val)
+			continue
+		}
+
+		// Fallback for irregular "Key....: value" spacing.
+		if key, val, ok := splitIPConfigFallback(line); ok {
+			pending = key
+			applyIPConfigValue(cur, key, val)
+			continue
+		}
+
+		// Continuation value for the previous key (e.g. second DNS server).
+		if pending != "" && (strings.HasPrefix(line, "   ") || strings.HasPrefix(line, "\t")) {
+			val := strings.TrimSpace(line)
+			if val == "" {
+				continue
+			}
+			applyIPConfigValue(cur, pending, val)
+		}
+	}
+	flush()
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+	return result
+}
+
+func normalizeIPConfigKey(k string) string {
+	k = strings.ToLower(strings.TrimSpace(k))
+	k = strings.Join(strings.Fields(k), " ")
+	return k
+}
+
+// splitIPConfigFallback handles property lines the main regex misses.
+// Uses the first " . :" / ".: " style separator, not the last colon (IPv6).
+func splitIPConfigFallback(line string) (key, val string, ok bool) {
+	// Find " : " after a run of dots.
+	idx := strings.Index(line, " : ")
+	if idx < 0 {
+		// "....:value" without spaces around colon
+		idx = strings.Index(line, ".:")
+		if idx < 0 {
+			return "", "", false
+		}
+		// include the dot before colon in the key side
+		key = strings.TrimSpace(strings.TrimRight(strings.TrimSpace(line[:idx+1]), ". "))
+		val = strings.TrimSpace(line[idx+2:])
+		if key == "" {
+			return "", "", false
+		}
+		return normalizeIPConfigKey(key), val, true
+	}
+	key = strings.TrimSpace(strings.TrimRight(strings.TrimSpace(line[:idx]), ". "))
+	val = strings.TrimSpace(line[idx+3:])
+	if key == "" {
+		return "", "", false
+	}
+	return normalizeIPConfigKey(key), val, true
+}
+
+func applyIPConfigValue(cur *model.HostInterface, key, val string) {
+	if cur == nil || val == "" || strings.EqualFold(val, "none") {
+		// Still record media state from empty gateway? skip empties.
+		if val == "" {
+			return
+		}
+	}
+	switch {
+	case strings.Contains(key, "description"):
+		cur.Description = val
+	case strings.Contains(key, "physical address"):
+		cur.MAC = normalizeMAC(val)
+	case strings.Contains(key, "dhcp enabled"):
+		cur.DHCP = val
+	case strings.Contains(key, "media state"):
+		// "Media disconnected"
+		if strings.Contains(strings.ToLower(val), "disconnect") {
+			cur.State = "DOWN"
+		} else {
+			cur.State = strings.ToUpper(val)
+		}
+	case strings.Contains(key, "ipv4 address") || key == "ip address":
+		if ip := stripPreferred(val); ip != "" {
+			cur.IPv4 = appendUnique(cur.IPv4, ip)
+			if cur.State == "" {
+				cur.State = "UP"
+			}
+		}
+	case strings.Contains(key, "subnet mask"):
+		// Attach mask to the last IPv4 if it has no prefix yet.
+		if len(cur.IPv4) > 0 && !strings.Contains(cur.IPv4[len(cur.IPv4)-1], "/") {
+			if pfx := subnetMaskToPrefix(val); pfx != "" {
+				cur.IPv4[len(cur.IPv4)-1] = cur.IPv4[len(cur.IPv4)-1] + "/" + pfx
+			}
+		}
+	case strings.Contains(key, "ipv6 address") || strings.Contains(key, "temporary ipv6") || strings.Contains(key, "link-local ipv6"):
+		if strings.Contains(key, "link-local") {
+			return // skip fe80 like Linux path
+		}
+		if ip := stripPreferred(val); ip != "" {
+			cur.IPv6 = appendUnique(cur.IPv6, ip)
+			if cur.State == "" {
+				cur.State = "UP"
+			}
+		}
+	case strings.Contains(key, "default gateway"):
+		if g := strings.TrimSpace(val); g != "" && !strings.EqualFold(g, "none") {
+			cur.Gateway = appendUnique(cur.Gateway, g)
+		}
+	case strings.Contains(key, "dns servers"):
+		if d := strings.TrimSpace(val); d != "" {
+			cur.DNS = appendUnique(cur.DNS, d)
+		}
+	case strings.Contains(key, "autconfiguration") || strings.Contains(key, "autoconfiguration"):
+		// ignore
+	}
+}
+
+func stripPreferred(val string) string {
+	val = strings.TrimSpace(val)
+	// "192.168.1.10(Preferred)" or with spaces
+	if i := strings.Index(val, "("); i > 0 {
+		val = strings.TrimSpace(val[:i])
+	}
+	if m := reIPv4Pref.FindStringSubmatch(val); m != nil {
+		return m[1]
+	}
+	if m := reIPv6Pref.FindStringSubmatch(val); m != nil {
+		return m[1]
+	}
+	return val
+}
+
+func normalizeMAC(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, "-", ":")
+	return strings.ToLower(s)
+}
+
+func appendUnique(slice []string, v string) []string {
+	for _, x := range slice {
+		if x == v {
+			return slice
+		}
+	}
+	return append(slice, v)
+}
+
+func subnetMaskToPrefix(mask string) string {
+	parts := strings.Split(strings.TrimSpace(mask), ".")
+	if len(parts) != 4 {
+		return ""
+	}
+	var total int
+	for _, p := range parts {
+		var n int
+		for _, c := range p {
+			if c < '0' || c > '9' {
+				return ""
+			}
+			n = n*10 + int(c-'0')
+		}
+		if n > 255 {
+			return ""
+		}
+		for n > 0 {
+			total += n & 1
+			n >>= 1
+		}
+	}
+	if total == 0 {
+		return ""
+	}
+	return itoa(total)
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [12]byte
+	i := len(b)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		b[i] = '-'
+	}
+	return string(b[i:])
+}
+
+func classifyWindowsAdapter(kind, name string) string {
+	k := strings.ToLower(kind)
+	n := strings.ToLower(name)
+	switch {
+	case strings.Contains(k, "wireless") || strings.Contains(n, "wi-fi") || strings.Contains(n, "wifi"):
+		return "wireless"
+	case strings.Contains(k, "ethernet") || strings.Contains(n, "ethernet"):
+		return "physical"
+	case strings.Contains(n, "bluetooth"):
+		return "bluetooth"
+	case strings.Contains(n, "vethernet") || strings.Contains(n, "hyper-v"):
+		return "hyper-v"
+	case strings.Contains(n, "wsl"):
+		return "wsl"
+	case strings.Contains(n, "loopback"):
+		return "loopback"
+	case strings.Contains(k, "tunnel") || strings.Contains(n, "tunnel"):
+		return "tunnel"
+	case strings.Contains(k, "unknown"):
+		return "virtual"
+	default:
+		return detectInterfaceType(name)
+	}
+}
+
+func detectInterfaceType(name string) string {
+	lower := strings.ToLower(name)
+	switch {
+	case lower == "lo" || strings.Contains(lower, "loopback") || strings.HasPrefix(lower, "lo"):
+		return "loopback"
+	case strings.Contains(lower, "bluetooth"):
+		return "bluetooth"
+	case strings.HasPrefix(lower, "vethernet") || strings.Contains(lower, "vethernet") || strings.Contains(lower, "hyper-v"):
+		return "hyper-v"
+	case strings.Contains(lower, "wsl"):
+		return "wsl"
+	case strings.HasPrefix(lower, "eth") || strings.HasPrefix(lower, "en") || strings.Contains(lower, "ethernet"):
+		return "physical"
+	case strings.HasPrefix(lower, "wl") || strings.Contains(lower, "wi-fi") || strings.Contains(lower, "wifi") || strings.Contains(lower, "wlan"):
+		return "wireless"
+	case strings.HasPrefix(lower, "veth"):
+		return "veth"
+	case strings.Contains(lower, "docker") || strings.HasPrefix(lower, "br-"):
+		return "bridge"
+	case strings.HasPrefix(lower, "wg"):
+		return "wireguard"
+	case strings.HasPrefix(lower, "tun") || strings.HasPrefix(lower, "tap"):
+		return "tun/tap"
+	case strings.Contains(lower, "local area connection"):
+		return "virtual"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/proc/host_ifaces_windows_test.go
+++ b/internal/proc/host_ifaces_windows_test.go
@@ -1,0 +1,104 @@
+//go:build windows
+
+package proc
+
+import (
+	"strings"
+	"testing"
+)
+
+const sampleIPConfig = `
+Windows IP Configuration
+
+   Host Name . . . . . . . . . . . . : DESKTOP-TEST
+
+Ethernet adapter Ethernet:
+
+   Connection-specific DNS Suffix  . :
+   Description . . . . . . . . . . . : Realtek PCIe GbE Family Controller
+   Physical Address. . . . . . . . . : AA-BB-CC-DD-EE-FF
+   DHCP Enabled. . . . . . . . . . . : Yes
+   IPv4 Address. . . . . . . . . . . : 192.168.3.164(Preferred)
+   Subnet Mask . . . . . . . . . . . : 255.255.255.0
+   Default Gateway . . . . . . . . . : 192.168.3.1
+   DNS Servers . . . . . . . . . . . : 1.1.1.1
+                                       8.8.8.8
+
+Wireless LAN adapter Wi-Fi:
+
+   Media State . . . . . . . . . . . : Media disconnected
+   Description . . . . . . . . . . . : Intel Wi-Fi
+   Physical Address. . . . . . . . . : 11-22-33-44-55-66
+   DHCP Enabled. . . . . . . . . . . : Yes
+
+Ethernet adapter vEthernet (WSL):
+
+   Connection-specific DNS Suffix  . :
+   Description . . . . . . . . . . . : Hyper-V Virtual Ethernet Adapter
+   Physical Address. . . . . . . . . : 00-15-5D-01-02-03
+   DHCP Enabled. . . . . . . . . . . : No
+   IPv4 Address. . . . . . . . . . . : 172.24.192.1(Preferred)
+   Subnet Mask . . . . . . . . . . . : 255.255.240.0
+   Default Gateway . . . . . . . . . :
+`
+
+func TestParseIPConfig(t *testing.T) {
+	ifaces := parseIPConfig(sampleIPConfig)
+	if len(ifaces) < 3 {
+		t.Fatalf("got %d adapters, want >= 3", len(ifaces))
+	}
+	var eth *struct {
+		name string
+	}
+	_ = eth
+	foundEth := false
+	for _, iface := range ifaces {
+		if iface.Name == "Ethernet" {
+			foundEth = true
+			if iface.Type != "physical" {
+				t.Errorf("Ethernet type = %q, want physical", iface.Type)
+			}
+			if iface.State != "UP" {
+				t.Errorf("Ethernet state = %q, want UP", iface.State)
+			}
+			if len(iface.IPv4) == 0 || !strings.HasPrefix(iface.IPv4[0], "192.168.3.164") {
+				t.Errorf("Ethernet IPv4 = %v", iface.IPv4)
+			}
+			if !strings.Contains(iface.IPv4[0], "/24") {
+				t.Errorf("expected /24 prefix on IPv4, got %v", iface.IPv4)
+			}
+			if len(iface.Gateway) == 0 || iface.Gateway[0] != "192.168.3.1" {
+				t.Errorf("Gateway = %v", iface.Gateway)
+			}
+			if iface.MAC != "aa:bb:cc:dd:ee:ff" {
+				t.Errorf("MAC = %q", iface.MAC)
+			}
+			if len(iface.DNS) < 2 {
+				t.Errorf("DNS = %v, want 1.1.1.1 and 8.8.8.8", iface.DNS)
+			}
+		}
+		if iface.Name == "Wi-Fi" && iface.State != "DOWN" {
+			t.Errorf("Wi-Fi state = %q, want DOWN", iface.State)
+		}
+		if strings.Contains(iface.Name, "WSL") && iface.Type != "wsl" && iface.Type != "hyper-v" {
+			// vEthernet (WSL) classified as hyper-v or wsl
+			if iface.Type == "unknown" {
+				t.Errorf("WSL adapter type unknown: %+v", iface)
+			}
+		}
+	}
+	if !foundEth {
+		t.Fatal("Ethernet adapter not found")
+	}
+}
+
+func TestListHostInterfacesIPConfigLive(t *testing.T) {
+	ifaces, src := listHostInterfacesWithSource()
+	if len(ifaces) == 0 {
+		t.Fatal("expected at least one host interface on Windows")
+	}
+	if src == "" {
+		t.Error("HostSource should be set")
+	}
+	t.Logf("source=%s count=%d first=%q", src, len(ifaces), ifaces[0].Name)
+}

--- a/internal/tui/constants.go
+++ b/internal/tui/constants.go
@@ -5,7 +5,7 @@ import "time"
 // Timing constants for the interactive TUI.
 const (
 	// refreshInterval is the auto-refresh cadence for the process/port/
-	// container/lock tabs. 3s mirrors top's default.
+	// container/lock/network tabs. 3s mirrors top's default.
 	refreshInterval = 3 * time.Second
 
 	// selectionDebounce delays the detail/tree fetch after the selection
@@ -22,9 +22,10 @@ const (
 // view renderer; keeping them in one place stops those three from drifting
 // apart (which would make clicks land on the wrong pane).
 const (
-	listPaneRatio   = 0.7 // process list vs. ancestry tree
-	detailPaneRatio = 0.7 // detail view vs. environment view
-	portPaneRatio   = 0.5 // port list vs. port detail
+	listPaneRatio    = 0.7 // process list vs. ancestry tree
+	detailPaneRatio  = 0.7 // detail view vs. environment view
+	portPaneRatio    = 0.5 // port list vs. port detail
+	networkPaneRatio = 0.5 // network list vs. attached containers
 )
 
 // Adaptive auto-refresh. The background-refresh cadence starts at

--- a/internal/tui/data.go
+++ b/internal/tui/data.go
@@ -65,6 +65,12 @@ func (m MainModel) refreshLocks() tea.Cmd {
 	}
 }
 
+func (m MainModel) refreshNetworks() tea.Cmd {
+	return func() tea.Msg {
+		return proc.ListNetworkSnapshot()
+	}
+}
+
 // mergeLocksAndOpenFiles returns the union of locks and open files. When the
 // same (pid, path) appears in both, the lock entry wins so the Type column
 // surfaces the lock kind (POSIX/FLOCK) and Mode reflects lock access rather
@@ -938,3 +944,409 @@ func (m *MainModel) updateLockTable() {
 }
 
 const openFilesDisplayCap = 100
+
+func (m *MainModel) getNetworkColumns() []table.Column {
+	cols := []table.Column{
+		{Title: "Source", Width: 8},
+		{Title: "Name", Width: 20},
+		{Title: "Kind", Width: 12},
+		{Title: "State", Width: 10},
+		{Title: "Address", Width: 22},
+		{Title: "Extra", Width: 18},
+	}
+	addArrow := func(idx int, col string) {
+		if m.sortNetworkCol == col {
+			arrow := " ↑"
+			if m.sortNetworkDesc {
+				arrow = " ↓"
+			}
+			cols[idx].Title += arrow
+		}
+	}
+	addArrow(0, "source")
+	addArrow(1, "name")
+	addArrow(2, "kind")
+	addArrow(3, "state")
+	addArrow(4, "address")
+	addArrow(5, "extra")
+	return cols
+}
+
+func (m *MainModel) rebuildNetworkEntries() {
+	entries := make([]networkEntry, 0, len(m.hostIfaces)+len(m.networks))
+	for _, h := range m.hostIfaces {
+		entries = append(entries, networkEntry{IsHost: true, Host: h})
+	}
+	for _, n := range m.networks {
+		entries = append(entries, networkEntry{IsHost: false, Net: n})
+	}
+	m.networkEntries = entries
+}
+
+func (m *MainModel) sortNetworkEntries(entries []networkEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		a, b := entries[i], entries[j]
+		key := func(e networkEntry) (source, name, kind, state, address, extra string) {
+			if e.IsHost {
+				ips := strings.Join(e.Host.IPv4, ", ")
+				gw := strings.Join(e.Host.Gateway, ", ")
+				return "Host", e.Host.Name, e.Host.Type, e.Host.State, ips, gw
+			}
+			return "Docker", e.Net.Name, e.Net.Driver, e.Net.Scope, e.Net.Subnet, e.Net.Gateway
+		}
+		as, an, ak, ast, aa, ae := key(a)
+		bs, bn, bk, bst, ba, be := key(b)
+		var n int
+		switch m.sortNetworkCol {
+		case "source":
+			n = cmp.Compare(as, bs)
+		case "kind":
+			n = cmp.Compare(strings.ToLower(ak), strings.ToLower(bk))
+		case "state":
+			n = cmp.Compare(strings.ToLower(ast), strings.ToLower(bst))
+		case "address":
+			n = cmp.Compare(aa, ba)
+		case "extra":
+			n = cmp.Compare(ae, be)
+		default: // name
+			n = cmp.Compare(strings.ToLower(an), strings.ToLower(bn))
+		}
+		if n == 0 {
+			// Host rows before Docker when equal; then name.
+			if a.IsHost != b.IsHost {
+				if a.IsHost {
+					return !m.sortNetworkDesc
+				}
+				return m.sortNetworkDesc
+			}
+			n = cmp.Compare(strings.ToLower(an), strings.ToLower(bn))
+		}
+		if m.sortNetworkDesc {
+			return n > 0
+		}
+		return n < 0
+	})
+}
+
+func (m *MainModel) updateNetworkTable() {
+	m.rebuildNetworkEntries()
+	m.sortNetworkEntries(m.networkEntries)
+
+	filter := strings.ToLower(strings.TrimSpace(m.networkInput.Value()))
+	existing := m.networkTable.Columns()
+	newCols := m.getNetworkColumns()
+	for i := range existing {
+		if i < len(newCols) && existing[i].Width > 0 {
+			newCols[i].Width = existing[i].Width
+		}
+	}
+	m.networkTable.SetColumns(newCols)
+
+	cols := m.networkTable.Columns()
+	w := func(i int) int {
+		if i < len(cols) {
+			return cols[i].Width
+		}
+		return 16
+	}
+
+	rows := make([]table.Row, 0, len(m.networkEntries))
+	filtered := make([]networkEntry, 0, len(m.networkEntries))
+	for _, e := range m.networkEntries {
+		if m.networkScope == networkScopeHost && !e.IsHost {
+			continue
+		}
+		if m.networkScope == networkScopeDocker && e.IsHost {
+			continue
+		}
+		var source, name, kind, state, address, extra string
+		if e.IsHost {
+			source = "Host"
+			name = e.Host.Name
+			kind = e.Host.Type
+			state = e.Host.State
+			address = strings.Join(e.Host.IPv4, ", ")
+			extra = strings.Join(e.Host.Gateway, ", ")
+			if extra == "" {
+				extra = e.Host.MAC
+			}
+		} else {
+			source = "Docker"
+			name = e.Net.Name
+			kind = e.Net.Driver
+			state = e.Net.Scope
+			if state == "" {
+				state = "—"
+			}
+			address = e.Net.Subnet
+			extra = e.Net.Gateway
+			if extra == "N/A" {
+				extra = e.Net.BridgeInterface
+			}
+		}
+		if filter != "" {
+			hay := strings.ToLower(fmt.Sprintf("%s %s %s %s %s %s %s",
+				source, name, kind, state, address, extra, e.Host.Description))
+			if !e.IsHost {
+				hay = strings.ToLower(fmt.Sprintf("%s %s %s %s %s %s %s",
+					source, name, kind, state, address, extra, e.Net.BridgeInterface))
+			}
+			if !strings.Contains(hay, filter) {
+				continue
+			}
+		}
+		filtered = append(filtered, e)
+		rows = append(rows, table.Row{
+			truncate(source, w(0)),
+			truncate(output.SanitizeTerminalLine(name), w(1)),
+			truncate(output.SanitizeTerminalLine(kind), w(2)),
+			truncate(output.SanitizeTerminalLine(state), w(3)),
+			truncate(output.SanitizeTerminalLine(address), w(4)),
+			truncate(output.SanitizeTerminalLine(extra), w(5)),
+		})
+	}
+	m.filteredEntries = filtered
+	m.networkTable.SetRows(rows)
+	m.updateNetworkDetails()
+}
+
+func (m *MainModel) updateNetworkDetails() {
+	idx := m.networkTable.Cursor()
+	if idx < 0 || idx >= len(m.filteredEntries) {
+		m.networkDetailTable.SetRows(nil)
+		return
+	}
+	e := m.filteredEntries[idx]
+	if e.IsHost {
+		m.updateHostIfaceDetails(e.Host)
+		return
+	}
+	m.ensureNetworkEndpointColumns()
+	net := e.Net
+	cols := m.networkDetailTable.Columns()
+	w := func(i int) int {
+		if i < len(cols) {
+			return cols[i].Width
+		}
+		return 16
+	}
+	rows := make([]table.Row, 0, len(net.Containers)+4)
+	// Network metadata first, then endpoints.
+	m.ensureNetworkDetailKVColumns()
+	// Prefer endpoint table when containers exist; always show KV meta in side panel.
+	// Use KV layout for a consistent host/docker experience.
+	kv := [][2]string{
+		{"Source", "Docker"},
+		{"Name", net.Name},
+		{"ID", net.ID},
+		{"Driver", net.Driver},
+		{"Scope", net.Scope},
+		{"Bridge", net.BridgeInterface},
+		{"Subnet", net.Subnet},
+		{"Gateway", net.Gateway},
+		{"Containers", fmt.Sprintf("%d", len(net.Containers))},
+	}
+	cols = m.networkDetailTable.Columns()
+	w0, w1 := 12, 36
+	if len(cols) > 0 {
+		w0 = cols[0].Width
+	}
+	if len(cols) > 1 {
+		w1 = cols[1].Width
+	}
+	for _, pair := range kv {
+		val := pair[1]
+		if val == "" {
+			val = "—"
+		}
+		rows = append(rows, table.Row{
+			truncate(output.SanitizeTerminalLine(pair[0]), w0),
+			truncate(output.SanitizeTerminalLine(val), w1),
+		})
+	}
+	for _, c := range net.Containers {
+		st := c.Status
+		if st == "" {
+			st = "?"
+		}
+		label := fmt.Sprintf("→ %s %s", st, c.Name)
+		rows = append(rows, table.Row{
+			truncate(output.SanitizeTerminalLine(label), w0),
+			truncate(output.SanitizeTerminalLine(c.IP), w1),
+		})
+	}
+	// silence unused
+	_ = w
+	m.networkDetailTable.SetRows(rows)
+}
+
+func (m *MainModel) ensureNetworkEndpointColumns() {
+	cols := m.networkDetailTable.Columns()
+	want := []table.Column{
+		{Title: "Status", Width: 8},
+		{Title: "Name", Width: 18},
+		{Title: "IP", Width: 20},
+		{Title: "MAC", Width: 18},
+	}
+	if len(cols) == 4 && cols[0].Title == "Status" {
+		return
+	}
+	// Preserve width budget from current table when possible.
+	if len(cols) == 4 {
+		for i := range want {
+			if cols[i].Width > 0 {
+				want[i].Width = cols[i].Width
+			}
+		}
+	}
+	m.networkDetailTable.SetColumns(want)
+}
+
+func (m *MainModel) ensureNetworkDetailKVColumns() {
+	want := []table.Column{
+		{Title: "Field", Width: 10},
+		{Title: "Value", Width: 36},
+	}
+	cols := m.networkDetailTable.Columns()
+	if len(cols) == 2 && cols[0].Title == "Field" {
+		return
+	}
+	if len(cols) >= 2 {
+		// Stretch value column from previous total width.
+		total := 0
+		for _, c := range cols {
+			total += c.Width
+		}
+		if total > 14 {
+			want[1].Width = total - want[0].Width
+		}
+	}
+	m.networkDetailTable.SetColumns(want)
+}
+
+func (m *MainModel) updateHostIfaceDetails(iface model.HostInterface) {
+	m.ensureNetworkDetailKVColumns()
+	cols := m.networkDetailTable.Columns()
+	w0, w1 := 12, 36
+	if len(cols) > 0 {
+		w0 = cols[0].Width
+	}
+	if len(cols) > 1 {
+		w1 = cols[1].Width
+	}
+	mtu := "n/a"
+	if iface.MTU > 0 {
+		mtu = fmt.Sprintf("%d", iface.MTU)
+	}
+	kv := [][2]string{
+		{"Source", "Host"},
+		{"Name", iface.Name},
+		{"Type", iface.Type},
+		{"State", iface.State},
+		{"Description", iface.Description},
+		{"MTU", mtu},
+		{"MAC", iface.MAC},
+		{"DHCP", iface.DHCP},
+		{"IPv4", strings.Join(iface.IPv4, ", ")},
+		{"IPv6", strings.Join(iface.IPv6, ", ")},
+		{"Gateway", strings.Join(iface.Gateway, ", ")},
+		{"DNS", strings.Join(iface.DNS, ", ")},
+		{"Index", fmt.Sprintf("%d", iface.IfIndex)},
+	}
+	rows := make([]table.Row, 0, len(kv))
+	for _, pair := range kv {
+		val := pair[1]
+		if val == "" {
+			val = "—"
+		}
+		rows = append(rows, table.Row{
+			truncate(output.SanitizeTerminalLine(pair[0]), w0),
+			truncate(output.SanitizeTerminalLine(val), w1),
+		})
+	}
+	m.networkDetailTable.SetRows(rows)
+}
+
+func (m *MainModel) selectedNetworkEntry() (networkEntry, bool) {
+	idx := m.networkTable.Cursor()
+	if idx < 0 || idx >= len(m.filteredEntries) {
+		return networkEntry{}, false
+	}
+	return m.filteredEntries[idx], true
+}
+
+func (m *MainModel) networkDetailContent() string {
+	e, ok := m.selectedNetworkEntry()
+	if !ok {
+		return "No network selected."
+	}
+	label := lipgloss.NewStyle().Foreground(colorSectionLabel).Bold(true)
+	muted := lipgloss.NewStyle().Foreground(colorMuted)
+	var b strings.Builder
+	if e.IsHost {
+		h := e.Host
+		fmt.Fprintf(&b, "%s\n", label.Render("Host interface"))
+		fmt.Fprintf(&b, "  Name        : %s\n", h.Name)
+		fmt.Fprintf(&b, "  Type        : %s\n", h.Type)
+		fmt.Fprintf(&b, "  State       : %s\n", h.State)
+		if h.Description != "" {
+			fmt.Fprintf(&b, "  Description : %s\n", h.Description)
+		}
+		fmt.Fprintf(&b, "  MAC         : %s\n", h.MAC)
+		if h.MTU > 0 {
+			fmt.Fprintf(&b, "  MTU         : %d\n", h.MTU)
+		}
+		if h.DHCP != "" {
+			fmt.Fprintf(&b, "  DHCP        : %s\n", h.DHCP)
+		}
+		fmt.Fprintf(&b, "  IPv4        : %s\n", orDash(strings.Join(h.IPv4, ", ")))
+		fmt.Fprintf(&b, "  IPv6        : %s\n", orDash(strings.Join(h.IPv6, ", ")))
+		fmt.Fprintf(&b, "  Gateway     : %s\n", orDash(strings.Join(h.Gateway, ", ")))
+		fmt.Fprintf(&b, "  DNS         : %s\n", orDash(strings.Join(h.DNS, ", ")))
+		if m.networkHostSrc != "" {
+			fmt.Fprintf(&b, "\n%s\n  %s\n", label.Render("Source tool"), muted.Render(m.networkHostSrc))
+		}
+		return b.String()
+	}
+	net := e.Net
+	fmt.Fprintf(&b, "%s\n", label.Render("Docker network"))
+	fmt.Fprintf(&b, "  Name     : %s\n", net.Name)
+	fmt.Fprintf(&b, "  ID       : %s\n", net.ID)
+	fmt.Fprintf(&b, "  Driver   : %s\n", net.Driver)
+	fmt.Fprintf(&b, "  Scope    : %s\n", net.Scope)
+	fmt.Fprintf(&b, "  Bridge   : %s\n", net.BridgeInterface)
+	fmt.Fprintf(&b, "  Subnet   : %s\n", net.Subnet)
+	fmt.Fprintf(&b, "  Gateway  : %s\n", net.Gateway)
+	fmt.Fprintf(&b, "\n%s\n", label.Render("Attached containers"))
+	if len(net.Containers) == 0 {
+		fmt.Fprintf(&b, "  %s\n", muted.Render("None"))
+	} else {
+		treeStyle := lipgloss.NewStyle().Foreground(colorTreeConn)
+		for i, c := range net.Containers {
+			prefix := "├──"
+			if i == len(net.Containers)-1 {
+				prefix = "└──"
+			}
+			st := c.Status
+			if st == "" {
+				st = "?"
+			}
+			fmt.Fprintf(&b, "  %s %s %s  %s\n",
+				treeStyle.Render(prefix), st, c.Name, c.IP)
+		}
+	}
+	if m.vethByBridge != nil {
+		if veths := m.vethByBridge[net.BridgeInterface]; len(veths) > 0 {
+			fmt.Fprintf(&b, "\n%s\n", label.Render("VETHs on bridge"))
+			fmt.Fprintf(&b, "  %s\n", strings.Join(veths, ", "))
+		}
+	}
+	return b.String()
+}
+
+func orDash(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -105,7 +105,24 @@ const (
 	tabPorts
 	tabContainers
 	tabLocks
+	tabNetwork
 )
+
+// networkScope filters Host / Docker rows on the Network tab.
+type networkScope int
+
+const (
+	networkScopeAll networkScope = iota
+	networkScopeHost
+	networkScopeDocker
+)
+
+// networkEntry is one row in the combined Host + Docker network table.
+type networkEntry struct {
+	IsHost bool
+	Host   model.HostInterface
+	Net    model.DockerNetwork
+}
 
 type modelState int
 
@@ -156,10 +173,21 @@ type MainModel struct {
 	containers         []*model.ContainerMatch
 	filteredContainers []*model.ContainerMatch
 	selectedContainer  *model.ContainerMatch
+	selectedNetwork    *model.DockerNetwork
 	lockTable          table.Model
 	lockInput          textinput.Model
 	locks              []*model.LockedFile
 	filteredLocks      []*model.LockedFile
+	networkTable       table.Model
+	networkDetailTable table.Model
+	networkInput       textinput.Model
+	networks           []model.DockerNetwork
+	hostIfaces         []model.HostInterface
+	networkEntries     []networkEntry // combined Host + Docker rows
+	filteredEntries    []networkEntry
+	vethByBridge       map[string][]string
+	networkErr         string
+	networkHostSrc     string // "ipconfig", "ip addr", …
 	statusMsg          string // transient status/error message shown in status line
 	width              int
 	height             int
@@ -175,10 +203,14 @@ type MainModel struct {
 	sortContainerDesc bool
 	sortLockCol       string
 	sortLockDesc      bool
+	sortNetworkCol    string
+	sortNetworkDesc   bool
 	showAllPorts      bool
 	showAllFiles      bool
-	showCmdCol        bool
-	version           string
+	// networkScope filters the combined Network table: all | host | docker.
+	networkScope networkScope
+	showCmdCol   bool
+	version      string
 
 	// Mouse double-click tracking
 	lastClickTime time.Time
@@ -285,6 +317,34 @@ func InitialModel(version string) MainModel {
 	)
 	lt.SetStyles(s)
 
+	networkColumns := []table.Column{
+		{Title: "Source", Width: 8},
+		{Title: "Name", Width: 20},
+		{Title: "Kind", Width: 12},
+		{Title: "State", Width: 10},
+		{Title: "Address", Width: 22},
+		{Title: "Extra", Width: 18},
+	}
+	nt := table.New(
+		table.WithColumns(networkColumns),
+		table.WithFocused(true),
+		table.WithHeight(20),
+	)
+	nt.SetStyles(s)
+
+	ndCols := []table.Column{
+		{Title: "Status", Width: 8},
+		{Title: "Name", Width: 18},
+		{Title: "IP", Width: 20},
+		{Title: "MAC", Width: 18},
+	}
+	ndt := table.New(
+		table.WithColumns(ndCols),
+		table.WithFocused(false),
+		table.WithHeight(20),
+	)
+	ndt.SetStyles(s)
+
 	li := textinput.New()
 	li.Placeholder = "Search PID, Process, Type, Mode, Path..."
 	li.CharLimit = 156
@@ -292,6 +352,14 @@ func InitialModel(version string) MainModel {
 	li.Prompt = "> "
 	li.PromptStyle = promptStyle
 	li.Blur()
+
+	ni := textinput.New()
+	ni.Placeholder = "Search Name, Driver, Subnet, Gateway, Bridge..."
+	ni.CharLimit = 156
+	ni.Width = 50
+	ni.Prompt = "> "
+	ni.PromptStyle = promptStyle
+	ni.Blur()
 
 	ci := textinput.New()
 	ci.Placeholder = "Search ID, Name, Runtime, Image, Status, Ports, Command..."
@@ -333,33 +401,40 @@ func InitialModel(version string) MainModel {
 	ri.Blur()
 
 	return MainModel{
-		state:             stateList,
-		table:             t,
-		portTable:         pt,
-		portDetailTable:   pdt,
-		containerTable:    ct,
-		containerInput:    ci,
-		lockTable:         lt,
-		lockInput:         li,
-		input:             ti,
-		portInput:         pi,
-		viewport:          vp,
-		treeViewport:      tvp,
-		envViewport:       evp,
-		reniceInput:       ri,
-		detailFocus:       focusDetail,
-		listFocus:         focusMain,
-		activeTab:         tabProcesses,
-		sortCol:           "mem",
-		sortDesc:          true,
-		sortPortCol:       "port",
-		sortPortDesc:      false,
-		sortContainerCol:  "name",
-		sortContainerDesc: false,
-		sortLockCol:       "pid",
-		sortLockDesc:      false,
-		version:           version,
-		refreshEvery:      refreshInterval,
+		state:              stateList,
+		table:              t,
+		portTable:          pt,
+		portDetailTable:    pdt,
+		containerTable:     ct,
+		containerInput:     ci,
+		lockTable:          lt,
+		lockInput:          li,
+		networkTable:       nt,
+		networkDetailTable: ndt,
+		networkInput:       ni,
+		input:              ti,
+		portInput:          pi,
+		viewport:           vp,
+		treeViewport:       tvp,
+		envViewport:        evp,
+		reniceInput:        ri,
+		detailFocus:        focusDetail,
+		listFocus:          focusMain,
+		activeTab:          tabProcesses,
+		sortCol:            "mem",
+		sortDesc:           true,
+		sortPortCol:        "port",
+		sortPortDesc:       false,
+		sortContainerCol:   "name",
+		sortContainerDesc:  false,
+		sortLockCol:        "pid",
+		sortLockDesc:       false,
+		sortNetworkCol:     "name",
+		sortNetworkDesc:    false,
+		// Combined Host + Docker by default.
+		networkScope: networkScopeAll,
+		version:      version,
+		refreshEvery: refreshInterval,
 	}
 }
 

--- a/internal/tui/mouse.go
+++ b/internal/tui/mouse.go
@@ -147,3 +147,36 @@ func (m *MainModel) handleLockHeaderClick(x int) {
 		}
 	}
 }
+
+func (m *MainModel) handleNetworkHeaderClick(x int) {
+	cols := m.networkTable.Columns()
+	colIdx := m.getColumnAtX(x, cols)
+
+	if colIdx >= 0 {
+		newCol := ""
+		switch colIdx {
+		case 0:
+			newCol = "source"
+		case 1:
+			newCol = "name"
+		case 2:
+			newCol = "kind"
+		case 3:
+			newCol = "state"
+		case 4:
+			newCol = "address"
+		case 5:
+			newCol = "extra"
+		}
+
+		if newCol != "" {
+			if m.sortNetworkCol == newCol {
+				m.sortNetworkDesc = !m.sortNetworkDesc
+			} else {
+				m.sortNetworkCol = newCol
+				m.sortNetworkDesc = false
+			}
+			m.updateNetworkTable()
+		}
+	}
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/muesli/reflow/wrap"
 	"github.com/pranshuparmar/witr/internal/proc"
 	"github.com/pranshuparmar/witr/pkg/model"
 )
@@ -47,6 +48,8 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleContainerList(msg)
 	case []*model.LockedFile:
 		return m.handleLockList(msg)
+	case model.NetworkSnapshot:
+		return m.handleNetworkSnapshot(msg)
 	case treeMsg:
 		return m.handleTree(msg)
 	case model.Result:
@@ -61,7 +64,7 @@ func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m MainModel) handleTick(msg tickMsg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
-	if m.state == stateList && !m.quitting && !m.input.Focused() && !m.portInput.Focused() && !m.containerInput.Focused() && !m.lockInput.Focused() && m.refreshDue() {
+	if m.state == stateList && !m.quitting && !m.input.Focused() && !m.portInput.Focused() && !m.containerInput.Focused() && !m.lockInput.Focused() && !m.networkInput.Focused() && m.refreshDue() {
 		m.lastRefresh = time.Now()
 		m.refreshStartedAt = m.lastRefresh
 		cmd = m.refreshProcesses()
@@ -72,6 +75,8 @@ func (m MainModel) handleTick(msg tickMsg) (tea.Model, tea.Cmd) {
 			cmd = tea.Batch(cmd, m.refreshContainers())
 		case tabLocks:
 			cmd = tea.Batch(cmd, m.refreshLocks())
+		case tabNetwork:
+			cmd = tea.Batch(cmd, m.refreshNetworks())
 		}
 	}
 	return m, tea.Batch(cmd, waitTick())
@@ -187,35 +192,57 @@ func (m MainModel) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		if m.lockInput.Focused() {
 			m.lockInput.Blur()
 		}
+		if m.networkInput.Focused() {
+			m.networkInput.Blur()
+		}
 	}
 
-	// Tabs. X ranges are inactiveTabStyle widths: "1. Processes"=14,
-	// "2. Ports"=10, "3. Containers"=15, "4. Locks"=10 (inc. 1ch padding).
+	// Tabs. Ranges are derived from inactive tab label widths (padding 0,1):
+	// "1. Processes"=14, "2. Ports"=10, "3. Containers"=15, "4. Locks"=10,
+	// "5. Network"=12. Title "witr" starts at X≈2 with brand padding → content
+	// from X=8. When Locks is hidden (Windows), Network shifts left.
 	if msg.Y == 1 && isClick {
-		if msg.X >= 8 && msg.X < 22 { // "1. Processes"
-			if m.activeTab != tabProcesses {
-				m.activeTab = tabProcesses
-				m.listFocus = focusMain
+		x := msg.X
+		// Brand title ~6 cells starting at 2 → tabs from 8.
+		cursor := 8
+		tabSpans := []struct {
+			tab   tab
+			width int
+		}{
+			{tabProcesses, 14},
+			{tabPorts, 10},
+			{tabContainers, 15},
+		}
+		if locksTabEnabled {
+			tabSpans = append(tabSpans, struct {
+				tab   tab
+				width int
+			}{tabLocks, 10})
+		}
+		tabSpans = append(tabSpans, struct {
+			tab   tab
+			width int
+		}{tabNetwork, 12})
+
+		for _, ts := range tabSpans {
+			if x >= cursor && x < cursor+ts.width {
+				if m.activeTab != ts.tab {
+					m.activeTab = ts.tab
+					m.listFocus = focusMain
+					switch ts.tab {
+					case tabPorts:
+						return m, m.refreshPorts()
+					case tabContainers:
+						return m, m.refreshContainers()
+					case tabLocks:
+						return m, m.refreshLocks()
+					case tabNetwork:
+						return m, m.refreshNetworks()
+					}
+				}
 				return m, nil
 			}
-		} else if msg.X >= 22 && msg.X < 32 { // "2. Ports"
-			if m.activeTab != tabPorts {
-				m.activeTab = tabPorts
-				m.listFocus = focusMain
-				return m, m.refreshPorts()
-			}
-		} else if msg.X >= 32 && msg.X < 47 { // "3. Containers"
-			if m.activeTab != tabContainers {
-				m.activeTab = tabContainers
-				m.listFocus = focusMain
-				return m, m.refreshContainers()
-			}
-		} else if locksTabEnabled && msg.X >= 47 && msg.X < 57 { // "4. Locks"
-			if m.activeTab != tabLocks {
-				m.activeTab = tabLocks
-				m.listFocus = focusMain
-				return m, m.refreshLocks()
-			}
+			cursor += ts.width
 		}
 	}
 
@@ -230,6 +257,8 @@ func (m MainModel) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			m.containerInput.Focus()
 		case tabLocks:
 			m.lockInput.Focus()
+		case tabNetwork:
+			m.networkInput.Focus()
 		}
 		return m, nil
 	}
@@ -250,6 +279,8 @@ func (m MainModel) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			return m.handleContainerAreaMouse(msg, contentX, isClick, isWheel, isDoubleClick)
 		case tabLocks:
 			return m.handleLockAreaMouse(msg, contentX, isClick, isWheel, isDoubleClick)
+		case tabNetwork:
+			return m.handleNetworkAreaMouse(msg, contentX, isClick, isWheel, isDoubleClick)
 		}
 	}
 	return m, nil
@@ -262,13 +293,13 @@ func (m MainModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.quitting = true
 		return m, tea.Quit
 	case "1":
-		if !m.input.Focused() && !m.portInput.Focused() && !m.containerInput.Focused() {
+		if !m.anySearchFocused() {
 			m.activeTab = tabProcesses
 			m.listFocus = focusMain
 			return m, nil
 		}
 	case "2":
-		if !m.input.Focused() && !m.portInput.Focused() && !m.containerInput.Focused() {
+		if !m.anySearchFocused() {
 			m.activeTab = tabPorts
 			m.listFocus = focusMain
 			m.portTable.Focus()
@@ -276,16 +307,24 @@ func (m MainModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, m.refreshPorts()
 		}
 	case "3":
-		if !m.input.Focused() && !m.portInput.Focused() && !m.containerInput.Focused() && !m.lockInput.Focused() {
+		if !m.anySearchFocused() {
 			m.activeTab = tabContainers
 			m.listFocus = focusMain
 			return m, m.refreshContainers()
 		}
 	case "4":
-		if locksTabEnabled && !m.input.Focused() && !m.portInput.Focused() && !m.containerInput.Focused() && !m.lockInput.Focused() {
+		if locksTabEnabled && !m.anySearchFocused() {
 			m.activeTab = tabLocks
 			m.listFocus = focusMain
 			return m, m.refreshLocks()
+		}
+	case "5":
+		if !m.anySearchFocused() {
+			m.activeTab = tabNetwork
+			m.listFocus = focusMain
+			m.networkTable.Focus()
+			m.networkDetailTable.Blur()
+			return m, m.refreshNetworks()
 		}
 	}
 
@@ -444,6 +483,61 @@ func (m MainModel) handleResize(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
 		m.lockTable.SetColumns(lockCols)
 	}
 
+	// Network split pane (Host + Docker combined table).
+	netPaneWidth := int(float64(availableWidth) * networkPaneRatio)
+	if netPaneWidth < 0 {
+		netPaneWidth = 0
+	}
+	netTableWidth := netPaneWidth - tablePadding
+	if netTableWidth < 0 {
+		netTableWidth = 0
+	}
+	netCols := m.getNetworkColumns()
+	// Stretch Address column.
+	fixedNet := 0
+	addrIdx := 4
+	for i, c := range netCols {
+		if i == addrIdx {
+			continue
+		}
+		fixedNet += c.Width
+	}
+	if addrIdx < len(netCols) {
+		sw := netTableWidth - fixedNet - cellPadding*len(netCols)
+		if sw < 10 {
+			sw = 10
+		}
+		netCols[addrIdx].Width = sw
+	}
+	m.networkTable.SetColumns(netCols)
+	m.networkTable.SetWidth(netTableWidth)
+	m.networkTable.SetHeight(processListHeight)
+
+	netDetailWidth := availableWidth - netPaneWidth - 5
+	if netDetailWidth < 10 {
+		netDetailWidth = 10
+	}
+	m.ensureNetworkDetailKVColumns()
+	ndCols := m.networkDetailTable.Columns()
+	fixedNd := 0
+	flexIdx := 1
+	for i, c := range ndCols {
+		if i == flexIdx {
+			continue
+		}
+		fixedNd += c.Width
+	}
+	if flexIdx < len(ndCols) {
+		nw := netDetailWidth - fixedNd - cellPadding*len(ndCols)
+		if nw < 10 {
+			nw = 10
+		}
+		ndCols[flexIdx].Width = nw
+	}
+	m.networkDetailTable.SetColumns(ndCols)
+	m.networkDetailTable.SetWidth(netDetailWidth)
+	m.networkDetailTable.SetHeight(processListHeight - 2)
+
 	vpHeight := msg.Height - 9
 	if vpHeight < 0 {
 		vpHeight = 0
@@ -461,7 +555,18 @@ func (m MainModel) handleResize(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
 	m.envViewport.Height = vpHeight
 
 	m.updatePortDetails()
+	// Rebuild network rows after column widths change so HOST/NETWORKS data
+	// is not left on stale empty rows from before the first WindowSizeMsg.
+	if len(m.hostIfaces) > 0 || len(m.networks) > 0 {
+		m.updateNetworkTable()
+	} else {
+		m.updateNetworkDetails()
+	}
 	return m, nil
+}
+
+func (m MainModel) anySearchFocused() bool {
+	return m.input.Focused() || m.portInput.Focused() || m.containerInput.Focused() || m.lockInput.Focused() || m.networkInput.Focused()
 }
 
 func (m MainModel) handleProcessList(msg []model.Process) (tea.Model, tea.Cmd) {
@@ -559,6 +664,43 @@ func (m MainModel) handleLockList(msg []*model.LockedFile) (tea.Model, tea.Cmd) 
 	return m, nil
 }
 
+func (m MainModel) handleNetworkSnapshot(msg model.NetworkSnapshot) (tea.Model, tea.Cmd) {
+	// Preserve selection by source+name across refresh.
+	var selSource, selName string
+	if e, ok := m.selectedNetworkEntry(); ok {
+		if e.IsHost {
+			selSource, selName = "Host", e.Host.Name
+		} else {
+			selSource, selName = "Docker", e.Net.Name
+		}
+	}
+
+	m.networks = msg.Networks
+	m.hostIfaces = msg.HostIfaces
+	m.vethByBridge = msg.VethByBridge
+	m.networkHostSrc = msg.HostSource
+	m.networkErr = msg.Error
+	if !msg.DockerOK && msg.Error == "" {
+		m.networkErr = "Docker not available"
+	}
+	m.updateNetworkTable()
+
+	if selName != "" {
+		for i, e := range m.filteredEntries {
+			src, name := "Docker", e.Net.Name
+			if e.IsHost {
+				src, name = "Host", e.Host.Name
+			}
+			if src == selSource && name == selName {
+				m.networkTable.SetCursor(i)
+				break
+			}
+		}
+		m.updateNetworkDetails()
+	}
+	return m, nil
+}
+
 func (m MainModel) handleTree(msg treeMsg) (tea.Model, tea.Cmd) {
 	selected := m.table.SelectedRow()
 	if len(selected) > 0 {
@@ -574,6 +716,7 @@ func (m MainModel) handleTree(msg treeMsg) (tea.Model, tea.Cmd) {
 func (m MainModel) handleResult(msg model.Result) (tea.Model, tea.Cmd) {
 	m.selectedDetail = &msg
 	m.selectedContainer = nil
+	m.selectedNetwork = nil
 	m.updateDetailViewport()
 	m.updateEnvViewport()
 	return m, nil
@@ -582,6 +725,7 @@ func (m MainModel) handleResult(msg model.Result) (tea.Model, tea.Cmd) {
 func (m MainModel) handleContainerDetail(msg *model.ContainerMatch) (tea.Model, tea.Cmd) {
 	m.selectedContainer = msg
 	m.selectedDetail = nil
+	m.selectedNetwork = nil
 	m.updateDetailViewport()
 	return m, nil
 }
@@ -591,6 +735,7 @@ func (m MainModel) handleError(msg error) (tea.Model, tea.Cmd) {
 	m.state = stateList
 	m.selectedDetail = nil
 	m.selectedContainer = nil
+	m.selectedNetwork = nil
 	m.statusMsg = fmt.Sprintf("Error: %v", msg)
 	return m, m.refreshProcesses()
 }
@@ -799,6 +944,100 @@ func (m MainModel) handleProcessAreaMouse(msg tea.MouseMsg, contentX int, isClic
 		}
 		return m, cmd
 	}
+}
+
+func (m MainModel) handleNetworkAreaMouse(msg tea.MouseMsg, contentX int, isClick, isWheel, isDoubleClick bool) (tea.Model, tea.Cmd) {
+	availableWidth := m.width - 6
+	netPaneWidth := int(float64(availableWidth) * networkPaneRatio)
+
+	if contentX < netPaneWidth {
+		if isClick {
+			m.listFocus = focusMain
+			m.networkDetailTable.Blur()
+			m.networkTable.Focus()
+			if msg.Y == 7 {
+				m.handleNetworkHeaderClick(contentX)
+				return m, nil
+			}
+		}
+
+		var cmd tea.Cmd
+		prevSelected := m.networkTable.Cursor()
+		if isWheel {
+			var keyMsg tea.KeyMsg
+			switch msg.Button {
+			case tea.MouseButtonWheelUp:
+				keyMsg = tea.KeyMsg{Type: tea.KeyUp}
+			case tea.MouseButtonWheelDown:
+				keyMsg = tea.KeyMsg{Type: tea.KeyDown}
+			}
+			m.networkTable, cmd = m.networkTable.Update(keyMsg)
+			if m.networkTable.Cursor() != prevSelected {
+				m.updateNetworkDetails()
+			}
+			return m, cmd
+		}
+
+		netMsg := msg
+		netMsg.X -= 2
+		netMsg.Y -= 7
+		if netMsg.X >= 0 && netMsg.Y >= 0 {
+			m.networkTable, cmd = m.networkTable.Update(netMsg)
+		}
+		if m.networkTable.Cursor() != prevSelected {
+			m.updateNetworkDetails()
+		}
+		if isDoubleClick && isClick && netMsg.Y > 0 {
+			if e, ok := m.selectedNetworkEntry(); ok {
+				m.state = stateDetail
+				m.selectedDetail = nil
+				m.selectedContainer = nil
+				if e.IsHost {
+					m.selectedNetwork = nil
+				} else {
+					net := e.Net
+					m.selectedNetwork = &net
+				}
+				if w := m.width - 6; w > 0 {
+					m.viewport.Width = w
+				}
+				content := m.networkDetailContent()
+				if m.viewport.Width > 0 {
+					content = wrap.String(content, m.viewport.Width)
+				}
+				m.viewport.SetContent(content)
+				m.viewport.GotoTop()
+				return m, nil
+			}
+		}
+		return m, cmd
+	}
+
+	// Side panel (interface details or attached containers)
+	if isClick {
+		m.listFocus = focusSide
+		m.networkTable.Blur()
+		m.networkDetailTable.Focus()
+	}
+	var cmd tea.Cmd
+	if isWheel {
+		var keyMsg tea.KeyMsg
+		switch msg.Button {
+		case tea.MouseButtonWheelUp:
+			keyMsg = tea.KeyMsg{Type: tea.KeyUp}
+		case tea.MouseButtonWheelDown:
+			keyMsg = tea.KeyMsg{Type: tea.KeyDown}
+		}
+		m.networkDetailTable, cmd = m.networkDetailTable.Update(keyMsg)
+		return m, cmd
+	}
+	sideMsg := msg
+	sideMsg.X -= netPaneWidth + 2
+	sideMsg.Y -= 8
+	if sideMsg.X >= 0 && sideMsg.Y >= 0 {
+		m.networkDetailTable, cmd = m.networkDetailTable.Update(sideMsg)
+	}
+	return m, cmd
 }
 
 func (m MainModel) handlePortAreaMouse(msg tea.MouseMsg, contentX int, isClick, isWheel, isDoubleClick bool) (tea.Model, tea.Cmd) {
@@ -1090,10 +1329,34 @@ func (m MainModel) handleListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					m.state = stateDetail
 					m.selectedDetail = nil
 					m.selectedContainer = nil
+					m.selectedNetwork = nil
 					m.viewport.GotoTop()
 					m.envViewport.GotoTop()
 					return m, m.fetchProcessDetail(pid)
 				}
+			}
+		}
+		if m.activeTab == tabNetwork {
+			if e, ok := m.selectedNetworkEntry(); ok {
+				m.state = stateDetail
+				m.selectedDetail = nil
+				m.selectedContainer = nil
+				if e.IsHost {
+					m.selectedNetwork = nil
+				} else {
+					net := e.Net
+					m.selectedNetwork = &net
+				}
+				if w := m.width - 6; w > 0 {
+					m.viewport.Width = w
+				}
+				content := m.networkDetailContent()
+				if m.viewport.Width > 0 {
+					content = wrap.String(content, m.viewport.Width)
+				}
+				m.viewport.SetContent(content)
+				m.viewport.GotoTop()
+				return m, nil
 			}
 		}
 		if m.activeTab == tabContainers {
@@ -1152,7 +1415,7 @@ func (m MainModel) handleListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	// Focus Switching
 	case "tab", "right", "left", "l", "L", "h", "H":
-		if m.input.Focused() || m.portInput.Focused() || m.containerInput.Focused() || m.lockInput.Focused() {
+		if m.anySearchFocused() {
 			break
 		}
 		// Tabs without a side panel — these keys are no-ops there.
@@ -1166,11 +1429,19 @@ func (m MainModel) handleListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					m.portTable.Blur()
 					m.portDetailTable.Focus()
 				}
+				if m.activeTab == tabNetwork {
+					m.networkTable.Blur()
+					m.networkDetailTable.Focus()
+				}
 			} else {
 				m.listFocus = focusMain
 				if m.activeTab == tabPorts {
 					m.portDetailTable.Blur()
 					m.portTable.Focus()
+				}
+				if m.activeTab == tabNetwork {
+					m.networkDetailTable.Blur()
+					m.networkTable.Focus()
 				}
 			}
 		} else if msg.String() == "shift+tab" || msg.String() == "left" || msg.String() == "h" || msg.String() == "H" {
@@ -1180,17 +1451,25 @@ func (m MainModel) handleListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					m.portDetailTable.Blur()
 					m.portTable.Focus()
 				}
+				if m.activeTab == tabNetwork {
+					m.networkDetailTable.Blur()
+					m.networkTable.Focus()
+				}
 			} else {
 				m.listFocus = focusSide
 				if m.activeTab == tabPorts {
 					m.portTable.Blur()
 					m.portDetailTable.Focus()
 				}
+				if m.activeTab == tabNetwork {
+					m.networkTable.Blur()
+					m.networkDetailTable.Focus()
+				}
 			}
 		}
 		return m, nil
 
-	// Toggle All Ports
+	// Toggle All Ports / open files / host ifaces
 	case "a", "A":
 		if m.activeTab == tabPorts {
 			m.showAllPorts = !m.showAllPorts
@@ -1205,10 +1484,27 @@ func (m MainModel) handleListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.lockTable.SetCursor(0)
 			return m, m.refreshLocks()
 		}
+		if m.activeTab == tabNetwork {
+			// Cycle ALL → HOST → DOCKER → ALL
+			switch m.networkScope {
+			case networkScopeAll:
+				m.networkScope = networkScopeHost
+			case networkScopeHost:
+				m.networkScope = networkScopeDocker
+			default:
+				m.networkScope = networkScopeAll
+			}
+			m.listFocus = focusMain
+			m.networkTable.Focus()
+			m.networkDetailTable.Blur()
+			m.networkTable.SetCursor(0)
+			m.updateNetworkTable()
+			return m, nil
+		}
 
 	// Sorting Keys (union across all tabs; per-tab dispatch below picks the relevant ones)
 	case "c", "C", "p", "P", "n", "N", "m", "M", "t", "T", "u", "U", "s", "S",
-		"i", "I", "r", "R", "g", "G", "f", "F":
+		"i", "I", "r", "R", "g", "G", "f", "F", "d", "D", "b", "B", "k", "K":
 		if nm, cmd, handled := m.handleSortKey(msg); handled {
 			return nm, cmd
 		} else {
@@ -1330,12 +1626,36 @@ func (m MainModel) handleDetailKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// Network and container detail are single-pane (no env split).
+	// Host network detail uses selectedNetwork==nil but stateDetail + viewport content.
+	if m.selectedNetwork != nil || m.selectedContainer != nil || (m.activeTab == tabNetwork && m.state == stateDetail && m.selectedDetail == nil) {
+		switch msg.String() {
+		case "esc", "q", "Q", "backspace":
+			m.state = stateList
+			m.selectedDetail = nil
+			m.selectedContainer = nil
+			m.selectedNetwork = nil
+			if m.activeTab == tabNetwork {
+				return m, m.refreshNetworks()
+			}
+			if m.activeTab == tabContainers {
+				return m, m.refreshContainers()
+			}
+			return m, nil
+		default:
+			var cmd tea.Cmd
+			m.viewport, cmd = m.viewport.Update(msg)
+			return m, cmd
+		}
+	}
+
 	// detail view navigation
 	switch msg.String() {
 	case "esc", "q", "Q", "backspace":
 		m.state = stateList
 		m.selectedDetail = nil
 		m.selectedContainer = nil
+		m.selectedNetwork = nil
 		m.detailFocus = focusDetail
 		m.actionMenuOpen = false
 		m.pendingAction = actionNone
@@ -1343,6 +1663,9 @@ func (m MainModel) handleDetailKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.reniceInput.Blur()
 		if m.activeTab == tabContainers {
 			return m, m.refreshContainers()
+		}
+		if m.activeTab == tabNetwork {
+			return m, m.refreshNetworks()
 		}
 		return m, m.refreshProcesses()
 	case "a", "A":
@@ -1375,7 +1698,27 @@ func (m MainModel) handleDetailKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m MainModel) handleListFilterInput(msg tea.KeyMsg) (MainModel, tea.Cmd, bool) {
-	if m.activeTab == tabLocks {
+	if m.activeTab == tabNetwork {
+		if m.networkInput.Focused() {
+			if msg.String() == "enter" || msg.String() == "esc" {
+				m.networkInput.Blur()
+				return m, nil, true
+			}
+			if msg.Type == tea.KeyUp || msg.Type == tea.KeyDown {
+				m.networkInput.Blur()
+			} else {
+				var inputCmd tea.Cmd
+				m.networkInput, inputCmd = m.networkInput.Update(msg)
+				m.updateNetworkTable()
+				m.networkTable.SetCursor(0)
+				return m, inputCmd, true
+			}
+		}
+		if msg.String() == "/" {
+			m.networkInput.Focus()
+			return m, textinput.Blink, true
+		}
+	} else if m.activeTab == tabLocks {
 		if m.lockInput.Focused() {
 			if msg.String() == "enter" || msg.String() == "esc" {
 				m.lockInput.Blur()
@@ -1590,6 +1933,33 @@ func (m MainModel) handleSortKey(msg tea.KeyMsg) (MainModel, tea.Cmd, bool) {
 			m.updateLockTable()
 			return m, nil, true
 		}
+
+	case tabNetwork:
+		newCol := ""
+		switch msg.String() {
+		case "s", "S":
+			newCol = "source"
+		case "n", "N":
+			newCol = "name"
+		case "k", "K":
+			newCol = "kind"
+		case "t", "T":
+			newCol = "state"
+		case "d", "D":
+			newCol = "address"
+		case "g", "G":
+			newCol = "extra"
+		}
+		if newCol != "" {
+			if m.sortNetworkCol == newCol {
+				m.sortNetworkDesc = !m.sortNetworkDesc
+			} else {
+				m.sortNetworkCol = newCol
+				m.sortNetworkDesc = false
+			}
+			m.updateNetworkTable()
+			return m, nil, true
+		}
 	}
 	return m, nil, false
 }
@@ -1627,6 +1997,13 @@ func (m MainModel) handleListNavKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		} else if m.activeTab == tabLocks {
 			m.lockTable, cmd = m.lockTable.Update(msg)
 			return m, cmd
+		} else if m.activeTab == tabNetwork {
+			prevSelected := m.networkTable.Cursor()
+			m.networkTable, cmd = m.networkTable.Update(msg)
+			if m.networkTable.Cursor() != prevSelected {
+				m.updateNetworkDetails()
+			}
+			return m, cmd
 		} else {
 			prevSelected := m.portTable.Cursor()
 			m.portTable, cmd = m.portTable.Update(msg)
@@ -1661,6 +2038,8 @@ func (m MainModel) handleListNavKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			default:
 				m.treeViewport, cmd = m.treeViewport.Update(msg)
 			}
+		} else if m.activeTab == tabNetwork {
+			m.networkDetailTable, cmd = m.networkDetailTable.Update(msg)
 		} else {
 			m.portDetailTable, cmd = m.portDetailTable.Update(msg)
 		}

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -45,6 +46,7 @@ func TestUpdateTabSwitch(t *testing.T) {
 		{"2", tabPorts},
 		{"3", tabContainers},
 		{"1", tabProcesses},
+		{"5", tabNetwork},
 	}
 	for _, tt := range tests {
 		// Start on a different tab so the switch is observable.
@@ -55,6 +57,81 @@ func TestUpdateTabSwitch(t *testing.T) {
 			t.Errorf("key %q: activeTab = %v, want %v", tt.key, m.activeTab, tt.want)
 		}
 	}
+}
+
+func TestUpdateToggleNetworkScope(t *testing.T) {
+	m := InitialModel("test")
+	m.activeTab = tabNetwork
+	if m.networkScope != networkScopeAll {
+		t.Fatalf("precondition: scope should start ALL, got %v", m.networkScope)
+	}
+	m, _ = step(t, m, keyRunes("a"))
+	if m.networkScope != networkScopeHost {
+		t.Errorf("first 'a' => HOST, got %v", m.networkScope)
+	}
+	m, _ = step(t, m, keyRunes("a"))
+	if m.networkScope != networkScopeDocker {
+		t.Errorf("second 'a' => DOCKER, got %v", m.networkScope)
+	}
+	m, _ = step(t, m, keyRunes("a"))
+	if m.networkScope != networkScopeAll {
+		t.Errorf("third 'a' => ALL, got %v", m.networkScope)
+	}
+}
+
+func TestHandleNetworkSnapshotCombinesHostAndDocker(t *testing.T) {
+	m := InitialModel("test")
+	m.activeTab = tabNetwork
+	m, _ = step(t, m, tea.WindowSizeMsg{Width: 140, Height: 40})
+	snap := model.NetworkSnapshot{
+		HostIfaces: []model.HostInterface{
+			{Name: "Ethernet", Type: "physical", State: "UP", MTU: 1500, IPv4: []string{"10.0.0.2/24"}, Gateway: []string{"10.0.0.1"}, MAC: "aa:bb:cc:dd:ee:ff"},
+			{Name: "Wi-Fi", Type: "wireless", State: "UP", IPv4: []string{"10.0.0.3/24"}},
+		},
+		Networks: []model.DockerNetwork{
+			{Name: "bridge", Driver: "bridge", Subnet: "172.17.0.0/16", Gateway: "172.17.0.1", BridgeInterface: "docker0"},
+		},
+		DockerOK:   true,
+		HostSource: "ipconfig /all",
+	}
+	m, _ = step(t, m, snap)
+	if len(m.hostIfaces) != 2 {
+		t.Fatalf("hostIfaces = %d", len(m.hostIfaces))
+	}
+	if len(m.networks) != 1 {
+		t.Fatalf("networks = %d", len(m.networks))
+	}
+	// ALL scope should show host + docker.
+	if got := len(m.networkTable.Rows()); got != 3 {
+		t.Fatalf("ALL table rows = %d, want 3 (2 host + 1 docker)", got)
+	}
+	view := m.View()
+	if !strings.Contains(view, "Ethernet") {
+		t.Errorf("view missing Ethernet; snippet %q", truncateForTest(view, 240))
+	}
+	if !strings.Contains(view, "bridge") && !strings.Contains(view, "Docker") {
+		t.Errorf("view missing docker network; snippet %q", truncateForTest(view, 240))
+	}
+
+	// HOST filter
+	m.networkScope = networkScopeHost
+	m.updateNetworkTable()
+	if got := len(m.networkTable.Rows()); got != 2 {
+		t.Errorf("HOST filter rows = %d, want 2", got)
+	}
+	// DOCKER filter
+	m.networkScope = networkScopeDocker
+	m.updateNetworkTable()
+	if got := len(m.networkTable.Rows()); got != 1 {
+		t.Errorf("DOCKER filter rows = %d, want 1", got)
+	}
+}
+
+func truncateForTest(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
 }
 
 func TestUpdateEnterOpensProcessDetail(t *testing.T) {
@@ -183,101 +260,6 @@ func TestUpdateResizeSetsDimsAndCmdColumn(t *testing.T) {
 	}
 }
 
-func TestUpdateProcessListMessage(t *testing.T) {
-	m := InitialModel("test")
-	m, cmd := step(t, m, []model.Process{{PID: 10, Command: "a"}, {PID: 20, Command: "b"}})
-	if len(m.processes) != 2 || len(m.filtered) != 2 {
-		t.Fatalf("process list message should populate processes/filtered, got %d/%d", len(m.processes), len(m.filtered))
-	}
-	if cmd == nil {
-		t.Error("a non-empty process list should schedule a tree fetch for the selection")
-	}
-}
-
-func TestUpdateDataListMessages(t *testing.T) {
-	m := InitialModel("test")
-
-	m, _ = step(t, m, []model.OpenPort{{Port: 80, Protocol: "tcp", State: "LISTEN"}})
-	if len(m.ports) != 1 {
-		t.Errorf("port list message: ports = %d, want 1", len(m.ports))
-	}
-
-	m, _ = step(t, m, []*model.ContainerMatch{{Name: "web"}})
-	if len(m.containers) != 1 {
-		t.Errorf("container list message: containers = %d, want 1", len(m.containers))
-	}
-
-	m, _ = step(t, m, []*model.LockedFile{{PID: 1, Path: "/a"}})
-	if len(m.locks) != 1 {
-		t.Errorf("lock list message: locks = %d, want 1", len(m.locks))
-	}
-}
-
-func TestUpdateResultMessageSetsDetail(t *testing.T) {
-	m := InitialModel("test")
-	res := model.Result{Process: model.Process{PID: 1, Command: "x"}, Ancestry: []model.Process{{PID: 1, Command: "x"}}}
-	m, _ = step(t, m, res)
-	if m.selectedDetail == nil {
-		t.Error("a Result message should populate selectedDetail")
-	}
-}
-
-func TestUpdateErrorMessageRevertsToList(t *testing.T) {
-	m := InitialModel("test")
-	m.state = stateDetail
-	m, cmd := step(t, m, error(fmt.Errorf("boom")))
-	if m.state != stateList {
-		t.Errorf("an error should revert to the list view, state = %v", m.state)
-	}
-	if m.statusMsg == "" {
-		t.Error("an error should surface a status message")
-	}
-	if cmd == nil {
-		t.Error("an error should trigger a process refresh")
-	}
-}
-
-func TestHandleTickRefreshesWhenDue(t *testing.T) {
-	m := InitialModel("test")
-	old := time.Now().Add(-time.Hour) // long past the cadence -> a tick is due
-	m.lastRefresh = old
-
-	nm, cmd := m.handleTick(tickMsg(time.Now()))
-	m = nm.(MainModel)
-	if !m.lastRefresh.After(old) {
-		t.Error("a due tick should advance lastRefresh")
-	}
-	if cmd == nil {
-		t.Error("handleTick must always reschedule the next tick")
-	}
-}
-
-func TestDetailKeyNavigation(t *testing.T) {
-	base := func() MainModel {
-		m := InitialModel("test")
-		m.state = stateDetail
-		m.selectedDetail = &model.Result{Process: model.Process{PID: 1}}
-		return m
-	}
-
-	t.Run("esc returns to list", func(t *testing.T) {
-		m, cmd := step(t, base(), tea.KeyMsg{Type: tea.KeyEsc})
-		if m.state != stateList || m.selectedDetail != nil {
-			t.Errorf("esc should return to list and clear detail; state=%v detail=%v", m.state, m.selectedDetail)
-		}
-		if cmd == nil {
-			t.Error("leaving detail should refresh the list")
-		}
-	})
-
-	t.Run("tab toggles detail/env focus", func(t *testing.T) {
-		m := base()
-		if m.detailFocus != focusDetail {
-			t.Fatalf("precondition: detailFocus = %v, want focusDetail", m.detailFocus)
-		}
-		m, _ = step(t, m, tea.KeyMsg{Type: tea.KeyTab})
-		if m.detailFocus != focusEnv {
-			t.Errorf("tab should move focus to the env pane, got %v", m.detailFocus)
-		}
-	})
-}
+// Keep time import used if other tests need it.
+var _ = time.Now
+var _ = fmt.Sprintf

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -23,8 +23,15 @@ func (m MainModel) View() string {
 	case stateList:
 		return m.viewList(outerStyle)
 	case stateDetail:
-		if m.selectedDetail == nil && m.selectedContainer == nil {
+		if m.selectedDetail == nil && m.selectedContainer == nil && m.selectedNetwork == nil {
+			// Host network detail reuses the network detail view with viewport content set.
+			if m.activeTab == tabNetwork {
+				return m.viewNetworkDetail(outerStyle)
+			}
 			return m.viewDetailLoading(outerStyle)
+		}
+		if m.selectedNetwork != nil || (m.activeTab == tabNetwork && m.selectedDetail == nil && m.selectedContainer == nil) {
+			return m.viewNetworkDetail(outerStyle)
 		}
 		if m.selectedContainer != nil {
 			return m.viewContainerDetail(outerStyle)
@@ -57,6 +64,11 @@ func (m MainModel) viewList(outerStyle lipgloss.Style) string {
 			status = "Mode: Searching (↑↓ to navigate, Esc/Enter to stop)"
 		}
 		inputView = m.lockInput.View()
+	case tabNetwork:
+		if m.networkInput.Focused() {
+			status = "Mode: Searching (↑↓ to navigate, Esc/Enter to stop)"
+		}
+		inputView = m.networkInput.View()
 	default:
 		if m.input.Focused() {
 			status = "Mode: Searching (↑↓ to navigate, Esc/Enter to stop)"
@@ -135,6 +147,57 @@ func (m MainModel) viewList(outerStyle lipgloss.Style) string {
 		mainContent = lipgloss.NewStyle().Width(m.width - 4).Render(m.lockTable.View())
 	}
 
+	if m.activeTab == tabNetwork {
+		s1 := cachedTableStyles
+		s1.Header = s.Header
+		m.networkTable.SetStyles(s1)
+
+		sideBorderColor := dimBorderColor
+		sideHeaderColor := colorHeaderDim
+		if m.listFocus == focusSide {
+			sideBorderColor = activeBorderColor
+			sideHeaderColor = activeBorderColor
+		}
+		s2 := cachedTableStyles
+		if m.listFocus == focusSide {
+			s2.Header = tableHeaderStyle.BorderForeground(activeBorderColor)
+		} else {
+			s2.Header = tableHeaderStyle.BorderForeground(dimBorderColor)
+		}
+		m.networkDetailTable.SetStyles(s2)
+
+		detailContainerStyle := detailDividerStyle.
+			BorderForeground(sideBorderColor).
+			Height(m.networkTable.Height())
+
+		detailHeader := "Details"
+		if e, ok := m.selectedNetworkEntry(); ok {
+			if e.IsHost {
+				detailHeader = "Host Interface"
+			} else {
+				detailHeader = "Docker Network"
+			}
+		}
+		availableWidth := m.width - 6
+		netPaneWidth := int(float64(availableWidth) * networkPaneRatio)
+		headerWidth := availableWidth - netPaneWidth - 3
+
+		detailHeaderStyle := tableHeaderStyle.
+			Width(headerWidth).
+			Foreground(sideHeaderColor).
+			BorderForeground(sideBorderColor)
+
+		mainContent = lipgloss.JoinHorizontal(lipgloss.Top,
+			lipgloss.NewStyle().Width(netPaneWidth).Render(m.networkTable.View()),
+			detailContainerStyle.Render(
+				lipgloss.JoinVertical(lipgloss.Left,
+					detailHeaderStyle.Render(detailHeader),
+					m.networkDetailTable.View(),
+				),
+			),
+		)
+	}
+
 	if m.activeTab == tabPorts {
 		sideBorderColor := dimBorderColor
 		sideHeaderColor := colorHeaderDim
@@ -208,6 +271,25 @@ func (m MainModel) viewList(outerStyle lipgloss.Style) string {
 			countText = fmt.Sprintf("%d of %d", shown, total)
 		}
 		helpText = fmt.Sprintf("%s [%s] | Enter: Detail | a: Toggle Open Files | p/n/t/m/f: Sort | /: Search | Esc/q: Quit | Up/Down: Scroll%s", countText, mode, suffix)
+	case tabNetwork:
+		mode := "ALL"
+		switch m.networkScope {
+		case networkScopeHost:
+			mode = "HOST"
+		case networkScopeDocker:
+			mode = "DOCKER"
+		}
+		total := len(m.networkTable.Rows())
+		src := ""
+		if m.networkHostSrc != "" {
+			src = " | via " + m.networkHostSrc
+		}
+		errHint := ""
+		if m.networkErr != "" && (m.networkScope == networkScopeDocker || m.networkScope == networkScopeAll) {
+			errHint = " | " + m.networkErr
+		}
+		helpText = fmt.Sprintf("Total: %d [%s]%s | Enter: Detail | a: Filter ALL/HOST/DOCKER | s/n/k: Sort | /: Search | Tab: Focus | Esc/q: Quit%s",
+			total, mode, src, errHint)
 	}
 	footerContent := helpText
 	if m.version != "" {
@@ -221,6 +303,7 @@ func (m MainModel) viewList(outerStyle lipgloss.Style) string {
 	portsTab := inactiveTabStyle.Render("2. Ports")
 	containersTab := inactiveTabStyle.Render("3. Containers")
 	locksTab := inactiveTabStyle.Render("4. Locks")
+	networkTab := inactiveTabStyle.Render("5. Network")
 	switch m.activeTab {
 	case tabProcesses:
 		processesTab = activeTabStyle.Render("1. Processes")
@@ -230,6 +313,8 @@ func (m MainModel) viewList(outerStyle lipgloss.Style) string {
 		containersTab = activeTabStyle.Render("3. Containers")
 	case tabLocks:
 		locksTab = activeTabStyle.Render("4. Locks")
+	case tabNetwork:
+		networkTab = activeTabStyle.Render("5. Network")
 	}
 
 	headerSegs := []string{
@@ -241,6 +326,7 @@ func (m MainModel) viewList(outerStyle lipgloss.Style) string {
 	if locksTabEnabled {
 		headerSegs = append(headerSegs, locksTab)
 	}
+	headerSegs = append(headerSegs, networkTab)
 	header := lipgloss.JoinHorizontal(lipgloss.Top, headerSegs...)
 
 	return outerStyle.Render(
@@ -309,6 +395,59 @@ func (m MainModel) viewContainerDetail(outerStyle lipgloss.Style) string {
 	// and Height-pinned pane that contains the title row plus the
 	// scrollable viewport. The pane absorbs any content/scroll
 	// variation so the surrounding layout stays put.
+	paneWidth := m.width - 4
+	if paneWidth < 1 {
+		paneWidth = 1
+	}
+	contentPane := lipgloss.NewStyle().
+		Width(paneWidth).
+		Height(m.viewport.Height + 2).
+		Render(lipgloss.JoinVertical(lipgloss.Left,
+			detailHeader.Width(m.viewport.Width).Render(title),
+			paddedStyle.Render(m.viewport.View()),
+		))
+
+	return outerStyle.Render(
+		lipgloss.JoinVertical(lipgloss.Left,
+			lipgloss.JoinHorizontal(lipgloss.Center, headerComponents...),
+			spacerStyle.Render(""),
+			contentPane,
+			spacerStyle.Render(""),
+			footerStyle.Width(m.width-4).Render(footerContent),
+		),
+	)
+}
+
+func (m MainModel) viewNetworkDetail(outerStyle lipgloss.Style) string {
+	activeBorderColor := colorAccent
+	detailHeader := tableHeaderStyle.
+		BorderForeground(activeBorderColor).
+		Foreground(activeBorderColor)
+	title := "Network Detail"
+	if !m.viewport.AtTop() && !m.viewport.AtBottom() {
+		title += " ↕"
+	} else if !m.viewport.AtTop() {
+		title += " ↑"
+	} else if !m.viewport.AtBottom() {
+		title += " ↓"
+	}
+
+	headerComponents := []string{titleStyle.Render("witr")}
+	if m.selectedNetwork != nil && m.selectedNetwork.Name != "" {
+		headerComponents = append(headerComponents, pidStyle.Render(m.selectedNetwork.Name))
+	} else if e, ok := m.selectedNetworkEntry(); ok && e.IsHost {
+		headerComponents = append(headerComponents, pidStyle.Render(e.Host.Name))
+	}
+
+	helpText := "Esc/q: Back | Up/Down: Scroll"
+	footerContent := helpText
+	if m.version != "" {
+		gap := m.width - 6 - lipgloss.Width(helpText) - lipgloss.Width(m.version)
+		if gap > 0 {
+			footerContent = helpText + strings.Repeat(" ", gap) + m.version
+		}
+	}
+
 	paneWidth := m.width - 4
 	if paneWidth < 1 {
 		paneWidth = 1

--- a/internal/tui/view_test.go
+++ b/internal/tui/view_test.go
@@ -27,7 +27,7 @@ func sized(t *testing.T, w, h int) MainModel {
 
 func TestViewListRendersEveryTab(t *testing.T) {
 	for _, sz := range [][2]int{{120, 40}, {80, 24}} {
-		for _, tabName := range []tab{tabProcesses, tabPorts, tabContainers, tabLocks} {
+		for _, tabName := range []tab{tabProcesses, tabPorts, tabContainers, tabLocks, tabNetwork} {
 			m := sized(t, sz[0], sz[1])
 			m.activeTab = tabName
 			out := m.View()

--- a/pkg/model/docker_network.go
+++ b/pkg/model/docker_network.go
@@ -1,0 +1,51 @@
+package model
+
+// HostInterface is a host network interface snapshot for the TUI Network tab.
+// Populated from OS-specific tools: ipconfig (Windows), ip addr (Linux), or
+// the portable Go net package as a fallback.
+type HostInterface struct {
+	Name        string
+	Type        string
+	State       string
+	MTU         int
+	MAC         string
+	IPv4        []string
+	IPv6        []string
+	Gateway     []string
+	DNS         []string
+	Description string
+	DHCP        string // "Yes" / "No" / ""
+	IfIndex     int
+}
+
+// DockerNetworkEndpoint is a container attached to a Docker network.
+type DockerNetworkEndpoint struct {
+	Name       string
+	ID         string
+	IP         string
+	MAC        string
+	EndpointID string
+	Status     string // short status text from docker ps when available
+}
+
+// DockerNetwork describes a Docker network and its endpoints.
+type DockerNetwork struct {
+	Name            string
+	ID              string
+	Driver          string
+	Scope           string
+	BridgeInterface string
+	Subnet          string
+	Gateway         string
+	Containers      []DockerNetworkEndpoint
+}
+
+// NetworkSnapshot is the full payload returned by a Network-tab refresh.
+type NetworkSnapshot struct {
+	Networks     []DockerNetwork
+	HostIfaces   []HostInterface
+	VethByBridge map[string][]string // bridge name → veth interface names (Linux best-effort)
+	DockerOK     bool
+	Error        string
+	HostSource   string // e.g. "ipconfig", "ip addr", "net" — for status hints
+}


### PR DESCRIPTION
# Pull Request: Network tab (host + Docker)  
thanks to 
@hbeigi-net


Add a fifth TUI tab that lists host machine adapters alongside Docker networks. Host data comes from ipconfig on Windows and ip addr on Linux, with a portable net fallback. Users can filter ALL/HOST/DOCKER and open detail panes for interfaces or network endpoints.

## Description

Adds a **Network** tab (key **`5`**) to the interactive TUI that shows **host machine network adapters** and **Docker networks** in one table.

- **Host data (OS-specific):**
  - Windows: `ipconfig /all` (with portable `net` fallback)
  - Linux: `ip -j addr show` → `ip addr show` → `net` fallback
  - Other: Go `net` package
- **Docker data:** `docker network ls` / `inspect` when the Docker CLI is available (including common Windows Docker Desktop paths)
- **Filter with `a`:** cycle **ALL → HOST → DOCKER → ALL**
- **Side panel + Enter:** host interface details (IPv4/IPv6, gateway, DNS, MAC, DHCP, …) or Docker network metadata and attached endpoints
- **Docs:** README TUI section updated for the new tab
- **Tests:** unit coverage for ipconfig parsing, network snapshot handling, and scope toggle

No linked issue number (local fork feature).

## Type of change

Check all that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (may affect existing functionality)
- [x] This change requires a documentation update

## Checklist

- [x] I have formatted my code using `go fmt ./...`
- [x] I have opened this PR against the `staging` branch
  *(use `staging` if opening upstream to pranshuparmar/witr; on the fork, PR target may be `main` depending on your branch setup)*
- [x] I have performed a self-review of my own code
- [x] I have added helpful comments where needed
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
  (`go test ./internal/proc/ ./internal/tui/ -count=1`)

## How to test

```bash
go build -o witr ./cmd/witr
./witr -i
```

1. Press **`5`** to open the Network tab.
2. Confirm **Host** rows (from `ipconfig` / `ip addr`) and **Docker** rows when Docker is available.
3. Press **`a`** to cycle **ALL / HOST / DOCKER**.
4. Select a row and check the side panel; press **Enter** for full detail.
5. Optional: `go test ./internal/proc/ ./internal/tui/ -count=1`

## Thank you for your contribution!

We’re excited to review your pull request. Please fill out the details above to help us understand your changes. Don’t worry if you can’t check every box, just do your best!
