### PR TITLE
fix(darwin): force LC_ALL=C for locale-sensitive ps invocations

### DIFF
--- a/internal/proc/process_list_darwin.go
+++ b/internal/proc/process_list_darwin.go
@@ -21,7 +21,9 @@ func ListProcesses() ([]model.Process, error) {
 	// "Microsoft Teams") which breaks the strings.Fields column parse used below;
 	// it is fetched separately via readPIDCommMap() so the display name is taken
 	// from an unambiguous source rather than re-derived from the space-joined args.
-	out, err := exec.Command("ps", "-axo", "pid,ppid,user,lstart,%cpu,rss,%mem,args").Output()
+	cmd := exec.Command("ps", "-axo", "pid,ppid,user,lstart,%cpu,rss,%mem,args")
+	cmd.Env = buildEnvForPS()
+	out, err := cmd.Output()
 	if err != nil {
 		// Fallback to fast snapshot if ps fails
 		return ListProcessSnapshot()

--- a/internal/proc/psenv_darwin_test.go
+++ b/internal/proc/psenv_darwin_test.go
@@ -1,0 +1,110 @@
+//go:build darwin
+
+package proc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// fakePSScript stands in for /bin/ps and renders lstart, %cpu and %mem the way
+// the real ps does under the locale it is invoked with: C uses the 5-token
+// English date and a dot decimal separator, ko_KR.UTF-8 a 7-token date, and
+// de_DE.UTF-8 a comma decimal separator.
+const fakePSScript = `#!/bin/sh
+case "$LC_ALL" in
+C)
+	lstart='Wed Jul 29 15:37:10 2026'
+	cpu='1.5'
+	mem='0.4'
+	;;
+ko_KR.UTF-8)
+	lstart='2026년  7월 29일 수요일 15시 37분 10초'
+	cpu='1.5'
+	mem='0.4'
+	;;
+*)
+	lstart='Mi. 29 Juli 15:37:10 2026'
+	cpu='1,5'
+	mem='0,4'
+	;;
+esac
+case "$*" in
+*comm=*)
+	printf '%s\n' " 4242 /usr/local/bin/witrtest"
+	;;
+*'%cpu=,rss='*)
+	printf '%s\n' "  $cpu 20480"
+	;;
+*)
+	printf '%s\n' "  PID  PPID USER     STARTED  %CPU   RSS %MEM ARGS"
+	printf '%s\n' " 4242     1 testuser $lstart $cpu 20480 $mem /usr/local/bin/witrtest --serve"
+	;;
+esac
+`
+
+func installFakePS(t *testing.T, locale string) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "ps"), []byte(fakePSScript), 0o755); err != nil {
+		t.Fatalf("write ps script: %v", err)
+	}
+	t.Setenv("PATH", dir+":"+os.Getenv("PATH"))
+	t.Setenv("LC_ALL", locale)
+}
+
+func TestListProcessesIgnoresCallerLocale(t *testing.T) {
+	wantStarted := time.Date(2026, time.July, 29, 15, 37, 10, 0, time.UTC)
+
+	for _, locale := range []string{"ko_KR.UTF-8", "de_DE.UTF-8"} {
+		t.Run(locale, func(t *testing.T) {
+			installFakePS(t, locale)
+
+			procs, err := ListProcesses()
+			if err != nil {
+				t.Fatalf("ListProcesses() error = %v", err)
+			}
+			if len(procs) != 1 {
+				t.Fatalf("ListProcesses() returned %d processes, want 1", len(procs))
+			}
+
+			p := procs[0]
+			if !p.StartedAt.Equal(wantStarted) {
+				t.Errorf("StartedAt = %v, want %v", p.StartedAt, wantStarted)
+			}
+			if p.CPUPercent != 1.5 {
+				t.Errorf("CPUPercent = %v, want 1.5", p.CPUPercent)
+			}
+			if p.MemoryRSS != 20480*1024 {
+				t.Errorf("MemoryRSS = %d, want %d", p.MemoryRSS, 20480*1024)
+			}
+			if p.MemoryPercent != 0.4 {
+				t.Errorf("MemoryPercent = %v, want 0.4", p.MemoryPercent)
+			}
+			if want := "/usr/local/bin/witrtest --serve"; p.Cmdline != want {
+				t.Errorf("Cmdline = %q, want %q", p.Cmdline, want)
+			}
+		})
+	}
+}
+
+func TestGetCPUAndMemoryUsageIgnoresCallerLocale(t *testing.T) {
+	for _, locale := range []string{"ko_KR.UTF-8", "de_DE.UTF-8"} {
+		t.Run(locale, func(t *testing.T) {
+			installFakePS(t, locale)
+
+			cpu, mem, err := getCPUAndMemoryUsage(4242)
+			if err != nil {
+				t.Fatalf("getCPUAndMemoryUsage() error = %v", err)
+			}
+			if cpu != 1.5 {
+				t.Errorf("cpu = %v, want 1.5", cpu)
+			}
+			if mem != 20480*1024 {
+				t.Errorf("mem = %d, want %d", mem, 20480*1024)
+			}
+		})
+	}
+}

--- a/internal/proc/resource_darwin.go
+++ b/internal/proc/resource_darwin.go
@@ -122,7 +122,9 @@ func getThermalState() string {
 
 func getCPUAndMemoryUsage(pid int) (float64, uint64, error) {
 	// Construct the command to execute
-	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "%cpu=,rss=").Output()
+	cmd := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "%cpu=,rss=")
+	cmd.Env = buildEnvForPS()
+	out, err := cmd.Output()
 
 	if err != nil {
 		return 0, 0, err


### PR DESCRIPTION
## Description

On macOS with a non-English locale, the TUI process list shows a blank **Started** column and wrong (usually `0.0%`) **CPU** and **MEM** values, and `GetResourceContext` reports 0 CPU / 0 memory. `ps` localises `lstart` and the decimal separator of `%cpu`/`%mem`, but two darwin call sites run it with the caller's environment instead of `buildEnvForPS()`.

Same `ps` command, three locales, run on macOS 26 (arm64):

```
$ for L in C ko_KR.UTF-8 de_DE.UTF-8 fr_FR.UTF-8; do
>   printf '%-12s ' "$L"; LC_ALL=$L ps -axo pid,ppid,user,lstart,%cpu,rss,%mem,args | sed -n 2p
> done

C                1     0 root   Wed Jul 29 15:37:10 2026       0.0  20032  0.1 /sbin/launchd
ko_KR.UTF-8      1     0 root   2026년  7월 29일 수요일 15시 37분 10초   0.0  20032  0.1 /sbin/launchd
de_DE.UTF-8      1     0 root   Mi. 29 Juli 15:37:10 2026      0,2  20032  0,1 /sbin/launchd
fr_FR.UTF-8      1     0 root   mer. 29 juil. 15:37:10 2026    0,2  20032  0,1 /sbin/launchd
```

Live `%cpu` for PID 1 jitters between samples, so here is what `ListProcesses()` produces from the fixed row the regression test feeds it — `4242 1 testuser <lstart> 1.5 20480 0.4 /usr/local/bin/witrtest --serve`, the same line rendered in each locale:

| locale | | `StartedAt` | `CPUPercent` | `MemoryRSS` | `MemoryPercent` | `Cmdline` |
|---|---|---|---|---|---|---|
| `ko_KR.UTF-8` | before | `0001-01-01 00:00:00` | `0` | `0` | **`1.5`** | **`"20480 0.4 /usr/local/bin/witrtest --serve"`** |
| | after | `2026-07-29 15:37:10` | `1.5` | `20971520` | `0.4` | `"/usr/local/bin/witrtest --serve"` |
| `de_DE.UTF-8` | before | `0001-01-01 00:00:00` | `0` | `20971520` | `0` | `"/usr/local/bin/witrtest --serve"` |
| | after | `2026-07-29 15:37:10` | `1.5` | `20971520` | `0.4` | `"/usr/local/bin/witrtest --serve"` |

Under `ko_KR` the column shift is total: `MemoryPercent` reports the *CPU* figure, and the raw `rss`/`%mem` values are prepended to `Cmdline`. The same behaviour reproduces against live `ps` on this machine (PID 1 under `ko_KR` came back with `StartedAt` zero, `MemoryRSS` 0, and `Cmdline` `"19984 0.1 /sbin/launchd"`).

`getCPUAndMemoryUsage()` additionally returns an error under `de_DE`/`fr_FR` before the change — `strconv.ParseFloat: parsing "0,1": invalid syntax` for live PID 1 — which makes `GetResourceContext` fall through with `CPUUsage: 0, MemoryUsage: 0`.

## Cause

Both parsers assume the C output.

`internal/proc/process_list_darwin.go` reads `lstart` as a fixed `fields[3:8]` slice. The Korean date is **7** whitespace tokens, not 5, so every later column shifts by two: `%cpu` and `rss` are read out of the middle of the date, `%mem` picks up the `%cpu` value, and `rss`/`%mem` leak into `Cmdline`.

German and French keep 5 tokens, so offsets survive, but they render decimals with a comma. `strconv.ParseFloat("0,1", 64)` fails and the ignored error leaves `CPUPercent`/`MemoryPercent` at 0. `internal/proc/resource_darwin.go` hits the same `ParseFloat` on `%cpu` and returns the error to `GetResourceContext`.

Neither call site sets `cmd.Env`.

## Fix

Set `cmd.Env = buildEnvForPS()` on both, which is exactly what `ReadProcess` in `process_darwin.go` and the FreeBSD twin `process_list_freebsd.go` already do. Darwin's list path appears to have simply been missed when a22496d fixed the FreeBSD one; the two files are otherwise line-for-line siblings. Four lines changed, no new helper, no new dependency.

### The `TZ=UTC` side of `buildEnvForPS()` — please read this part

`buildEnvForPS()` pins `TZ=UTC` as well as `LC_ALL=C`, so this PR also changes the timezone `ps` reports `lstart` in. That fixes a second, separate defect at the same line: `time.Parse("Mon Jan 2 15:04:05 2006", …)` has always produced a UTC `time.Time`, but `ps` was handing it *local* wall-clock digits, so the resulting instant was wrong by the UTC offset. On this UTC+05:30 machine, live PID 1 read as `2026-07-29 15:37:10 UTC` before and the correct `2026-07-29 10:07:10 UTC` after. This is the same bug fefe0fb fixed for `ReadProcess` in December ("on macOS it was printing the wrong start time depending on the user's local timezone").

The visible cost, stated plainly, because it is what you will actually want to decide on:

| platform | `ListProcesses().StartedAt` origin | zone |
|---|---|---|
| linux | `startTimeFromTicks` over `time.Unix(btime, 0)` — `boot_linux.go:29` | Local |
| windows | `time.Unix(0, creation.Nanoseconds())` — `peb_windows.go:281` | Local |
| darwin, today | `time.Parse` of local wall-clock digits mislabelled UTC | UTC-labelled, local digits |
| darwin, after this PR | `time.Parse` of true UTC | **UTC** |

`internal/tui/data.go:277` renders that column with `p.StartedAt.Format("Jan 02 15:04:05")` — no `.Local()`, no zone label. So today all three platforms display local digits, and after this PR **darwin alone displays UTC**. This does not make the column consistent; it makes darwin the outlier, in exchange for the underlying instant finally being right. The change that would make all three agree is a `.Local()` at `internal/tui/data.go:277`, which I have deliberately left out as a separate concern — happy to send it as a follow-up if you want it.

To be precise about what does *not* change: `ListProcesses()` has exactly one non-test caller, `internal/tui/data.go:23`, and its `StartedAt` is consumed only at `data.go:277` (display) and `data.go:173` (sort by `UnixNano`, unaffected by a uniform shift). There is no `time.Since` downstream of it. The 90-day check at `internal/source/detect.go:210` and every `output.FormatStartedAt` call site are fed by `ReadProcess`, which has had `TZ=UTC` since 2b9456b, so this PR does not touch them.

The alternative is to hand-roll an `LC_ALL=C`-only environment here instead of reusing the helper. I did not, because it would leave the mislabelled-instant bug in place and would make this one of five `ps` call sites with a bespoke env instead of the shared one. If you would rather take the locale fix alone for now, say the word and I will switch it.

## Tests

New `internal/proc/psenv_darwin_test.go`:

- `TestListProcessesIgnoresCallerLocale`
- `TestGetCPUAndMemoryUsageIgnoresCallerLocale`

Both install a `ps` shim on `PATH` (same pattern as the existing `lsof` shim in `process_darwin_test.go`) that renders the Korean and German formats above. Keying the fixture off `$LC_ALL` rather than the machine's real locales means the test is deterministic and does not need `ko_KR.UTF-8`/`de_DE.UTF-8` to be installed on the runner.

**I verified the tests fail without the fix.** Reverting only the two source files and keeping the test:

```
=== RUN   TestListProcessesIgnoresCallerLocale/ko_KR.UTF-8
    psenv_darwin_test.go:75: StartedAt = 0001-01-01 00:00:00 +0000 UTC, want 2026-07-29 15:37:10 +0000 UTC
    psenv_darwin_test.go:78: CPUPercent = 0, want 1.5
    psenv_darwin_test.go:81: MemoryRSS = 0, want 20971520
    psenv_darwin_test.go:84: MemoryPercent = 1.5, want 0.4
    psenv_darwin_test.go:87: Cmdline = "20480 0.4 /usr/local/bin/witrtest --serve", want "/usr/local/bin/witrtest --serve"
=== RUN   TestListProcessesIgnoresCallerLocale/de_DE.UTF-8
    psenv_darwin_test.go:75: StartedAt = 0001-01-01 00:00:00 +0000 UTC, want 2026-07-29 15:37:10 +0000 UTC
    psenv_darwin_test.go:78: CPUPercent = 0, want 1.5
    psenv_darwin_test.go:84: MemoryPercent = 0, want 0.4
--- FAIL: TestListProcessesIgnoresCallerLocale (0.23s)
=== RUN   TestGetCPUAndMemoryUsageIgnoresCallerLocale/de_DE.UTF-8
    psenv_darwin_test.go:100: getCPUAndMemoryUsage() error = strconv.ParseFloat: parsing "1,5": invalid syntax
--- FAIL: TestGetCPUAndMemoryUsageIgnoresCallerLocale (0.22s)
FAIL	github.com/pranshuparmar/witr/internal/proc	0.919s
```

With the fix restored, all four subtests pass. (`TestGetCPUAndMemoryUsageIgnoresCallerLocale/ko_KR.UTF-8` passes either way — Korean uses a dot decimal separator, so only the German subtest pins that site.)

## Local validation

CI won't run automatically on a first-time contributor's fork PR, so this is the only pre-merge validation I control. Everything below was run locally on macOS 26 / arm64, Go 1.25.10, against this branch:

| Command | Result |
|---|---|
| `go test ./...` | 8/8 packages `ok` |
| `go test -race ./...` | 8/8 packages `ok`, no races — see the flake note below |
| `go vet ./...` | clean |
| `gofmt -l` on the 3 changed files | empty |
| `golangci-lint v2.12.2 run` under `GOOS=linux`/`darwin`/`windows`/`freebsd` | `0 issues.` on all four |
| `go mod vendor && git diff --exit-code -- vendor go.mod go.sum` | in sync |
| `go build ./cmd/witr` + cross-compile linux/darwin ×amd64+arm64, windows/amd64, freebsd/amd64 | 6/6 build |

The same suite is green on `staging` at `63f557c` before this change, so there are no pre-existing failures being carried.

One caveat on the race row, since I would rather flag it than claim more than I saw: `TestIntegration_ResolvePortNonexistent` (`internal/target/integration_test.go:157`) failed once on this machine during review of this branch, and passed on every subsequent run — 2 clean full-suite race runs plus 5 clean `-count=1 -race ./internal/target` runs. It binds a port, closes it, and retries `ResolvePort` for 10×50 ms waiting for the kernel to release it; under load that window can expire. It is in a different package, does not touch `internal/proc`, and is unrelated to this change — but "no races, always" is not something I can honestly assert about this suite.

## Possible sibling issue — not touched here

`internal/proc/resource_linux.go:148` and `internal/proc/resource_freebsd.go:23` also parse `ps %cpu` with `ParseFloat` and no `LC_ALL=C`. **I could not test those** — I only have a macOS host, and I don't have a citation for whether procps or FreeBSD's `ps` localise the decimal separator the way BSD `ps` on darwin does, so I'm not claiming it's a bug. Want me to include them in this PR, or open a separate one if you can confirm?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (may affect existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] I have formatted my code using `go fmt ./...`
- [x] I have opened this PR against the `staging` branch
- [x] I have performed a self-review of my own code
- [x] I have added helpful comments where needed
- [ ] I have made corresponding changes to the documentation — not applicable, no user-facing docs describe this
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

---

Disclosure: I used Claude to help investigate and write this change. I reproduced the `ps` behaviour, ran every command listed above, and reviewed the diff myself.
