### PR TITLE
fix(install): create the bin directory before installing the binary

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -107,6 +107,7 @@ if [[ "$need_sudo" == "1" ]]; then
 fi
 
 # Install
+${SUDO[@]+"${SUDO[@]}"} mkdir -p "$INSTALL_BIN_DIR"
 ${SUDO[@]+"${SUDO[@]}"} install -m 755 "$TMP" "$INSTALL_PATH"
 
 # Install man page


### PR DESCRIPTION
`install.sh` fails on any machine where the install prefix's `bin` directory does not exist and is not writable by the invoking user. on Apple Silicon macOS that is the default state, since Homebrew lives under `/opt/homebrew` and nothing ever creates `/usr/local/bin`.

what happens: the writability probe runs `mkdir -p "$INSTALL_BIN_DIR"` as the unprivileged user, that fails, so `need_sudo=1` and the script correctly falls through to `sudo install`. but the directory still is not there, and BSD `install` writes a temp file inside the destination directory before renaming it into place, so you get:

```
install: /usr/local/bin/INS@JblGN6: No such file or directory
```

the man page path already handles this, with `mkdir -p "$INSTALL_MAN_DIR"` immediately before its `install` call. the bin path just does not have the matching line. this adds it.

verified against a prefix whose `bin` directory is missing and not writable by the invoking user: that exact error reproduces without the change, and the install completes cleanly with it. the no-sudo path (`INSTALL_PREFIX="$HOME/.local"`) is unaffected, since the probe creates the directory there anyway. `install.ps1` has no equivalent gap, it already creates `$InstallDir` before extracting.
