### PR TITLE
fix(proc): stop ancestry at recycled parent PIDs

### DIFF
--- a/internal/proc/ancestry.go
+++ b/internal/proc/ancestry.go
@@ -7,6 +7,10 @@ import (
 )
 
 func ResolveAncestry(pid int) ([]model.Process, error) {
+	return resolveAncestry(pid, ReadProcess)
+}
+
+func resolveAncestry(pid int, readProcess func(int) (model.Process, error)) ([]model.Process, error) {
 	var chain []model.Process
 	seen := make(map[int]bool)
 
@@ -18,9 +22,22 @@ func ResolveAncestry(pid int) ([]model.Process, error) {
 		}
 		seen[current] = true
 
-		p, err := ReadProcess(current)
+		p, err := readProcess(current)
 		if err != nil {
 			break
+		}
+
+		// A real parent must have started no later than its child. If the
+		// process currently occupying the PPID is newer, the original parent
+		// exited and its PID was recycled while (or before) we walked the
+		// chain. Stop here instead of stitching an unrelated process onto the
+		// ancestry. Some platforms can leave start times unavailable, so only
+		// enforce the invariant when both values are known.
+		if len(chain) > 0 {
+			child := chain[len(chain)-1]
+			if !p.StartedAt.IsZero() && !child.StartedAt.IsZero() && p.StartedAt.After(child.StartedAt) {
+				break
+			}
 		}
 
 		chain = append(chain, p)

--- a/internal/proc/ancestry_test.go
+++ b/internal/proc/ancestry_test.go
@@ -1,0 +1,101 @@
+package proc
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/pranshuparmar/witr/pkg/model"
+)
+
+func processMapReader(processes map[int]model.Process) func(int) (model.Process, error) {
+	return func(pid int) (model.Process, error) {
+		process, ok := processes[pid]
+		if !ok {
+			return model.Process{}, fmt.Errorf("process %d not found", pid)
+		}
+		return process, nil
+	}
+}
+
+func TestResolveAncestryOrdersParentChainFromRoot(t *testing.T) {
+	now := time.Now()
+	processes := map[int]model.Process{
+		1:   {PID: 1, Command: "init", StartedAt: now.Add(-3 * time.Hour)},
+		100: {PID: 100, PPID: 1, Command: "shell", StartedAt: now.Add(-2 * time.Hour)},
+		200: {PID: 200, PPID: 100, Command: "worker", StartedAt: now.Add(-time.Hour)},
+	}
+
+	chain, err := resolveAncestry(200, processMapReader(processes))
+	if err != nil {
+		t.Fatalf("resolveAncestry: %v", err)
+	}
+
+	want := []int{1, 100, 200}
+	if len(chain) != len(want) {
+		t.Fatalf("chain length = %d, want %d: %+v", len(chain), len(want), chain)
+	}
+	for i, pid := range want {
+		if chain[i].PID != pid {
+			t.Errorf("chain[%d].PID = %d, want %d", i, chain[i].PID, pid)
+		}
+	}
+}
+
+func TestResolveAncestryStopsBeforeRecycledParentPID(t *testing.T) {
+	now := time.Now()
+	processes := map[int]model.Process{
+		// PID 100 now belongs to an unrelated process that started after its
+		// supposed child. It must not be included in the returned chain.
+		100: {PID: 100, PPID: 1, Command: "unrelated-shell", StartedAt: now.Add(-30 * time.Minute)},
+		200: {PID: 200, PPID: 100, Command: "parent", StartedAt: now.Add(-2 * time.Hour)},
+		300: {PID: 300, PPID: 200, Command: "worker", StartedAt: now.Add(-time.Hour)},
+	}
+
+	chain, err := resolveAncestry(300, processMapReader(processes))
+	if err != nil {
+		t.Fatalf("resolveAncestry: %v", err)
+	}
+
+	want := []int{200, 300}
+	if len(chain) != len(want) {
+		t.Fatalf("chain length = %d, want %d: %+v", len(chain), len(want), chain)
+	}
+	for i, pid := range want {
+		if chain[i].PID != pid {
+			t.Errorf("chain[%d].PID = %d, want %d", i, chain[i].PID, pid)
+		}
+	}
+}
+
+func TestResolveAncestryKeepsParentsWithUnknownStartTimes(t *testing.T) {
+	processes := map[int]model.Process{
+		1:   {PID: 1, Command: "init"},
+		200: {PID: 200, PPID: 1, Command: "worker"},
+	}
+
+	chain, err := resolveAncestry(200, processMapReader(processes))
+	if err != nil {
+		t.Fatalf("resolveAncestry: %v", err)
+	}
+	if len(chain) != 2 || chain[0].PID != 1 || chain[1].PID != 200 {
+		t.Fatalf("chain = %+v, want PIDs [1 200]", chain)
+	}
+}
+
+func TestResolveAncestryKeepsEqualStartTimes(t *testing.T) {
+	startedAt := time.Now()
+	processes := map[int]model.Process{
+		1:   {PID: 1, Command: "init", StartedAt: startedAt.Add(-time.Hour)},
+		100: {PID: 100, PPID: 1, Command: "fast-parent", StartedAt: startedAt},
+		200: {PID: 200, PPID: 100, Command: "fast-child", StartedAt: startedAt},
+	}
+
+	chain, err := resolveAncestry(200, processMapReader(processes))
+	if err != nil {
+		t.Fatalf("resolveAncestry: %v", err)
+	}
+	if len(chain) != 3 || chain[0].PID != 1 || chain[1].PID != 100 || chain[2].PID != 200 {
+		t.Fatalf("chain = %+v, want PIDs [1 100 200]", chain)
+	}
+}


### PR DESCRIPTION
## Description

Fixes #220.

The ancestry walk now validates each resolved parent's start time against its child before adding that parent to the chain. If the current process occupying a PPID started after its supposed child, the walk stops at the last valid process instead of stitching an unrelated recycled PID into the ancestry.

The check is intentionally skipped when either timestamp is unavailable, and equal timestamps remain valid for platforms with coarse process start-time resolution. An internal reader seam makes the edge cases deterministic to test without changing the public API.

### Validation

- `make lint`
- `go test -v ./...`
- `go test -race ./...`
- `CGO_ENABLED=0 go build` for linux/amd64, linux/arm64, darwin/amd64, and darwin/arm64

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (may affect existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] I have formatted my code using `go fmt ./...`
- [x] I have opened this PR against the `staging` branch
- [x] I have performed a self-review of my own code
- [x] I have added helpful comments where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

### AI assistance

AI assistance was used to investigate the issue, implement the focused change, and draft tests. The resulting diff was reviewed and the repository's lint, full test, race-test, and cross-build checks were run locally.

## Thank you for your contribution! 🎉
