### PR TITLE
fix(windows): normalize localized listener states

### DIFF
--- a/internal/proc/net_windows.go
+++ b/internal/proc/net_windows.go
@@ -14,7 +14,10 @@ func ListOpenPorts() ([]model.OpenPort, error) {
 	if err != nil {
 		return nil, err
 	}
+	return parseOpenPorts(out), nil
+}
 
+func parseOpenPorts(out []byte) []model.OpenPort {
 	lines := strings.Split(string(out), "\n")
 	var ports []model.OpenPort
 	seen := make(map[string]bool)
@@ -39,10 +42,7 @@ func ListOpenPorts() ([]model.OpenPort, error) {
 			state = "LISTEN"
 		} else if len(fields) >= 5 {
 			pidStr = fields[4]
-			state = fields[3]
-			if state == "LISTENING" {
-				state = "LISTEN"
-			}
+			state = normalizeWindowsTCPState(fields[3], fields[2])
 		}
 
 		pid, err := strconv.Atoi(pidStr)
@@ -76,7 +76,7 @@ func ListOpenPorts() ([]model.OpenPort, error) {
 			}
 		}
 	}
-	return ports, nil
+	return ports
 }
 
 // GetSocketsForPID returns every IP socket owned by a PID, including
@@ -107,10 +107,7 @@ func GetSocketsForPID(pid int) []model.Socket {
 			if len(fields) < 5 {
 				continue
 			}
-			state = fields[3]
-			if state == "LISTENING" {
-				state = "LISTEN"
-			}
+			state = normalizeWindowsTCPState(fields[3], fields[2])
 			matchPID = fields[4]
 		} else if strings.HasPrefix(proto, "UDP") {
 			state = "OPEN"
@@ -151,4 +148,13 @@ func GetSocketsForPID(pid int) []model.Socket {
 		})
 	}
 	return sockets
+}
+
+func normalizeWindowsTCPState(state, remoteAddr string) string {
+	// netstat localizes state names, but a listening row is identifiable by
+	// its zero-port remote endpoint in every locale.
+	if state == "LISTENING" || strings.HasSuffix(remoteAddr, ":0") {
+		return "LISTEN"
+	}
+	return strings.ToValidUTF8(state, "?")
 }

--- a/internal/proc/net_windows.go
+++ b/internal/proc/net_windows.go
@@ -150,10 +150,24 @@ func GetSocketsForPID(pid int) []model.Socket {
 	return sockets
 }
 
+// normalizeWindowsTCPState maps a netstat state token to the name the rest of
+// witr uses.
+//
+// netstat localizes the token, so a non-English console reports ABHÖREN or
+// ECOUTE rather than LISTENING, in the console's OEM code page. The zero-port
+// remote endpoint identifies a listener in every locale, but it is not unique
+// to one: BOUND and CLOSED rows also carry 0.0.0.0:0. So the English names are
+// matched first and the endpoint is only consulted for a token this build does
+// not recognize.
 func normalizeWindowsTCPState(state, remoteAddr string) string {
-	// netstat localizes state names, but a listening row is identifiable by
-	// its zero-port remote endpoint in every locale.
-	if state == "LISTENING" || strings.HasSuffix(remoteAddr, ":0") {
+	switch state {
+	case "LISTENING":
+		return "LISTEN"
+	case "ESTABLISHED", "TIME_WAIT", "CLOSE_WAIT", "SYN_SENT", "SYN_RECEIVED",
+		"FIN_WAIT_1", "FIN_WAIT_2", "LAST_ACK", "CLOSING", "CLOSED", "BOUND", "DELETE_TCB":
+		return state
+	}
+	if strings.HasSuffix(remoteAddr, ":0") {
 		return "LISTEN"
 	}
 	return strings.ToValidUTF8(state, "?")

--- a/internal/proc/net_windows_test.go
+++ b/internal/proc/net_windows_test.go
@@ -1,0 +1,19 @@
+package proc
+
+import "testing"
+
+func TestParseOpenPortsNormalizesLocalizedListenerState(t *testing.T) {
+	// German netstat emits ABHÖREN in the active console code page. The raw
+	// 0x99 byte below is how Ö is represented in CP850 and is invalid UTF-8,
+	// matching the garbled ABH?REN state reported in #227.
+	out := append([]byte("TCP  0.0.0.0:8080  0.0.0.0:0  ABH"), 0x99)
+	out = append(out, []byte("REN  4242\r\n")...)
+
+	ports := parseOpenPorts(out)
+	if len(ports) != 1 {
+		t.Fatalf("parseOpenPorts() returned %d ports, want 1", len(ports))
+	}
+	if ports[0].State != "LISTEN" {
+		t.Fatalf("listener state = %q, want LISTEN", ports[0].State)
+	}
+}

--- a/internal/proc/net_windows_test.go
+++ b/internal/proc/net_windows_test.go
@@ -1,19 +1,40 @@
+//go:build windows
+
 package proc
 
 import "testing"
 
-func TestParseOpenPortsNormalizesLocalizedListenerState(t *testing.T) {
-	// German netstat emits ABHÖREN in the active console code page. The raw
-	// 0x99 byte below is how Ö is represented in CP850 and is invalid UTF-8,
-	// matching the garbled ABH?REN state reported in #227.
-	out := append([]byte("TCP  0.0.0.0:8080  0.0.0.0:0  ABH"), 0x99)
-	out = append(out, []byte("REN  4242\r\n")...)
+func TestNormalizeWindowsTCPState(t *testing.T) {
+	cases := []struct {
+		name       string
+		state      string
+		remoteAddr string
+		want       string
+	}{
+		{"english listener", "LISTENING", "0.0.0.0:0", "LISTEN"},
+		{"german listener", "ABH\xd6REN", "0.0.0.0:0", "LISTEN"},
+		{"french listener", "ECOUTE", "0.0.0.0:0", "LISTEN"},
+		{"ipv6 listener", "LISTENING", "[::]:0", "LISTEN"},
 
-	ports := parseOpenPorts(out)
-	if len(ports) != 1 {
-		t.Fatalf("parseOpenPorts() returned %d ports, want 1", len(ports))
+		// A zero remote port is not unique to a listener, so these must keep
+		// their own state rather than being reported as listeners.
+		{"bound is not a listener", "BOUND", "0.0.0.0:0", "BOUND"},
+		{"closed is not a listener", "CLOSED", "0.0.0.0:0", "CLOSED"},
+		{"delete_tcb is not a listener", "DELETE_TCB", "0.0.0.0:0", "DELETE_TCB"},
+
+		{"established passes through", "ESTABLISHED", "127.0.0.1:443", "ESTABLISHED"},
+		{"time_wait passes through", "TIME_WAIT", "127.0.0.1:443", "TIME_WAIT"},
+
+		// Unrecognized and with a real peer: keep it, but make it printable.
+		{"unknown localized state with a peer", "\xc9TABLI", "127.0.0.1:443", "?TABLI"},
 	}
-	if ports[0].State != "LISTEN" {
-		t.Fatalf("listener state = %q, want LISTEN", ports[0].State)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeWindowsTCPState(tc.state, tc.remoteAddr); got != tc.want {
+				t.Fatalf("normalizeWindowsTCPState(%q, %q) = %q, want %q",
+					tc.state, tc.remoteAddr, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Description

Windows `netstat` localizes TCP state names, so the Ports tab's strict English-state check drops listeners and can pass invalid OEM bytes into the TUI.

Detect listener rows from their zero-port remote endpoint and normalize them to `LISTEN`. The parser regression covers German CP850 `ABHÖREN`.

Fixes #227.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (may affect existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] I have formatted my code using `go fmt ./...`
- [x] I have opened this PR against the `staging` branch
- [x] I have performed a self-review of my own code
- [x] I have added helpful comments where needed
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Testing

- `go vet ./cmd/... ./internal/... ./pkg/...`
- `go test ./cmd/... ./internal/... ./pkg/...`
- Cross-built Linux amd64/arm64, macOS amd64/arm64, Windows amd64, and FreeBSD amd64